### PR TITLE
Authentication id() method missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.DS_Store

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -274,6 +274,17 @@ class AuthenticationBase
 
 
     /**
+     * Returns the User ID for the current logged in user.
+     *
+     * @return int|null
+     */
+    public function id()
+    {
+        return $this->user->id;
+    }
+
+
+    /**
      * Returns the User instance for the current logged in user.
      *
      * @return \Myth\Auth\Entities\User|null


### PR DESCRIPTION
This function was missing and it's necessary to fulfill access authorization requests