### PR TITLE
Fix Authorization service

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -4,8 +4,8 @@ use CodeIgniter\Model;
 use Myth\Auth\Authorization\FlatAuthorization;
 use Myth\Auth\Models\UserModel;
 use Myth\Auth\Models\LoginModel;
-use Myth\Authorization\GroupModel;
-use Myth\Authorization\PermissionModel;
+use Myth\Auth\Authorization\GroupModel;
+use Myth\Auth\Authorization\PermissionModel;
 use Myth\Auth\Authentication\Passwords\PasswordValidator;
 use CodeIgniter\Config\BaseService;
 
@@ -43,7 +43,7 @@ class Services extends BaseService
     {
         if ($getShared)
         {
-            return self::getSharedInstance('authorization', $groupModel, $permissionModel);
+            return self::getSharedInstance('authorization', $groupModel, $permissionModel, $userModel);
         }
 
         if (is_null($groupModel))


### PR DESCRIPTION
`getSharedInstance` always pushes `false` onto the return call for a service, but since the Authorization is partially overloaded it thinks this is an incoming `userModel` and throws a type exception. Including $userModel in the shared instance call fixes this.
While on this file, a couple fo the `use` namespaces were incorrect.