### PR TITLE
Drop constraints before tables

### DIFF
--- a/src/Database/Migrations/20171120223112_create_auth_tables.php
+++ b/src/Database/Migrations/20171120223112_create_auth_tables.php
@@ -153,15 +153,23 @@ class Migration_create_auth_tables extends Migration
 
     public function down()
     {
-//        $this->forge->dropForeignKey('auth_tokens','user_id_foreign');
+		// drop constraints first to prevent errors
+		$this->forge->dropForeignKey('auth_tokens', 'auth_tokens_user_id_foreign');
+		$this->forge->dropForeignKey('auth_groups_permissions', 'auth_groups_permissions_group_id_foreign');
+		$this->forge->dropForeignKey('auth_groups_permissions', 'auth_groups_permissions_permission_id_foreign');
+		$this->forge->dropForeignKey('auth_groups_users', 'auth_groups_users_group_id_foreign');
+		$this->forge->dropForeignKey('auth_groups_users', 'auth_groups_users_user_id_foreign');
+		$this->forge->dropForeignKey('auth_users_permissions', 'auth_users_permissions_user_id_foreign');
+		$this->forge->dropForeignKey('auth_users_permissions', 'auth_users_permissions_permission_id_foreign');
 
-        $this->forge->dropTable('users', true);
-        $this->forge->dropTable('auth_login_attempts', true);
-        $this->forge->dropTable('auth_tokens', true);
-        $this->forge->dropTable('auth_groups', true);
-        $this->forge->dropTable('auth_permissions', true);
-        $this->forge->dropTable('auth_groups_permissions', true);
-        $this->forge->dropTable('auth_groups_users', true);
-        $this->forge->dropTable('auth_users_permissions', true);
+		$this->forge->dropTable('users', true);
+		$this->forge->dropTable('auth_login_attempts', true);
+		$this->forge->dropTable('auth_tokens', true);
+		$this->forge->dropTable('auth_reset_attempts', true);
+		$this->forge->dropTable('auth_groups', true);
+		$this->forge->dropTable('auth_permissions', true);
+		$this->forge->dropTable('auth_groups_permissions', true);
+		$this->forge->dropTable('auth_groups_users', true);
+		$this->forge->dropTable('auth_users_permissions', true);
     }
 }


### PR DESCRIPTION
Migration rollbacks currently fail because of foreign key constraints. Dropping foreign keys before the tables fixes the issues but may not be supported by all drivers. This is probably a larger Forge question of how to handle FKs, but this fix should make the migration work for up/down.