### PR TITLE
Fix for #17 (low priority)

### DIFF
--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -176,7 +176,7 @@ class Publish extends BaseCommand
         $path = "{$this->sourcePath}/Views/{$prefix}{$view}";
 
         $content = file_get_contents($path);
-        $content = str_replace('Myth\Auth\Views', 'Auth', $content);
+        $content = str_replace('Myth\Auth\Views', 'App\Auth', $content);
 
         $this->writeFile("Views/Auth/{$prefix}{$view}", $content);
     }

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -174,9 +174,10 @@ class Publish extends BaseCommand
     protected function publishView($view, string $prefix = '')
     {
         $path = "{$this->sourcePath}/Views/{$prefix}{$view}";
+		$namespace = defined('APP_NAMESPACE') ? APP_NAMESPACE : 'App';
 
         $content = file_get_contents($path);
-        $content = str_replace('Myth\Auth\Views', 'App\Auth', $content);
+        $content = str_replace('Myth\Auth\Views', $namespace.'\Auth', $content);
 
         $this->writeFile("Views/Auth/{$prefix}{$view}", $content);
     }


### PR DESCRIPTION
auth:publish injects the App namespace into view files, but is missing the full `App\` qualification.