### PR TITLE
Update filters, support silent operation, allow user config

### DIFF
--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -49,6 +49,17 @@ class AuthenticationBase
         return $this->error;
     }
 
+    /**
+     * Whether to continue instead of throwing exceptions,
+     * as defined in config.
+     *
+     * @return string
+     */
+    public function silent()
+    {
+        return $this->silent;
+    }
+
 
     /**
      * Logs a user into the system.

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -57,7 +57,7 @@ class AuthenticationBase
      */
     public function silent()
     {
-        return $this->silent;
+        return $this->config->silent;
     }
 
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -54,6 +54,13 @@ class Auth extends BaseConfig
     public $rememberLength = 30 * DAY;
 
     //--------------------------------------------------------------------
+    // Error handling
+    //--------------------------------------------------------------------
+    // If true, will continue instead of throwing exceptions.
+    //
+    public $silent = false;
+
+    //--------------------------------------------------------------------
     // PASSWORD HASHING COST
     //--------------------------------------------------------------------
     // The BCRYPT method of encryption allows you to define the "cost"

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -17,8 +17,16 @@ class Services extends BaseService
         {
             return self::getSharedInstance('authentication', $lib, $userModel, $loginModel);
         }
-
-        $config = config(Auth::class);
+		
+		// prioritizes user config in app/Config if found
+		if (class_exists('\Config\Auth'))
+		{
+			$config = config('Config\\Auth');
+		}
+		else
+		{
+			$config = config(Auth::class);
+		}
 
         $class = $config->authenticationLibs[$lib];
 

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -23,18 +23,32 @@ class PermissionFilter implements FilterInterface
      */
     public function before(RequestInterface $request, $params = null)
     {
+		if (empty($params))
+		{
+			return;
+		}
+		
         $authenticate = Services::authentication();
-
-        if (! $authenticate->check() || empty($params))
+		
+		// if no user is logged in then send to the login form
+        if (! $authenticate->check())
         {
-            return;
+            return redirect('login');
         }
 
         $authorize = Services::authorization();
 
         if (! $authorize->hasPermission($params, $authenticate->id()))
         {
-            throw new \RuntimeException('You do not have permission to view that page.');
+        	if ($authenticate->silent())
+        	{
+				$redirectURL = session('redirect_url') ?? '/';
+				unset($_SESSION['redirect_url']);
+				return redirect()->to($redirectURL)->with('error', lang('Auth.notEnoughPrivilege'));
+        	}
+        	else {
+        		throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
+        	}
         }
     }
 


### PR DESCRIPTION
* Filters now redirect un-authenticated users to named-route `login`
* On failure, filters will check the new `$silent` config value, and throw or redirect accordingly
* In order to expose config to users the authentication service now prioritizes app/Config/Auth.php
