### PR TITLE
Add login/logout events

### DIFF
--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -1,6 +1,7 @@
 <?php namespace Myth\Auth\Authentication;
 
 use Config\App;
+use CodeIgniter\Events\Events;
 use CodeIgniter\Model;
 use Myth\Auth\Config\Services;
 use Myth\Auth\Entities\User;
@@ -97,6 +98,9 @@ class AuthenticationBase
             $this->loginModel->purgeOldRememberTokens();
         }
 
+		// trigger login event, in case anyone cares
+		Events::trigger('login', $user);
+
         return true;
     }
 
@@ -168,6 +172,9 @@ class AuthenticationBase
 
         // Take care of any remember me functionality
         $this->loginModel->purgeRememberTokens($user->id);
+        
+        // trigger logout event
+		Events::trigger('logout', $user);
     }
 
     /**


### PR DESCRIPTION
Fires events `login` and `logout` respectively, with the attached `$user` as a parameter.
This will allow auth tracking in the Events toolbar collector and listeners from other libraries.
