### PR TITLE
Change command dashes to underscores

### DIFF
--- a/src/Commands/CreateGroup.php
+++ b/src/Commands/CreateGroup.php
@@ -7,10 +7,10 @@ use CodeIgniter\Config\Services;
 class CreateGroup extends BaseCommand
 {
     protected $group       = 'Auth';
-    protected $name        = 'auth:create-group';
+    protected $name        = 'auth:create_group';
     protected $description = "Adds a new group to the database.";
     
-	protected $usage     = "auth:create-group [name] [description]";
+	protected $usage     = "auth:create_group [name] [description]";
 	protected $arguments = [
 		'name'        => "The name of the new group to create",
 		'description' => "Optional description 'in quotes'",

--- a/src/Commands/ListGroups.php
+++ b/src/Commands/ListGroups.php
@@ -6,8 +6,9 @@ use CodeIgniter\CLI\CLI;
 class ListGroups extends BaseCommand
 {
     protected $group       = 'Auth';
-    protected $name        = 'auth:list-groups';
+    protected $name        = 'auth:list_groups';
     protected $description = 'Lists groups from the database.';
+    protected $usage       = 'auth:list_groups';
 
     public function run(array $params)
     {


### PR DESCRIPTION
Apparently spark doesn't like dashes in command names. The commands were originally "groups:list" so I didn't catch this before, but renaming them with underscores for now so they will work.