### PR TITLE
Remove `name` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,10 @@ $routes->group('admin', ['filter' => 'role:admin,superadmin'], function($routes)
     ...
 });
 ```
+
+## Customization
+
+This library is intentionally slim on user identifying information, having only the fields necessary for
+authentication and authorization. You will likely want to add fields like a user's name or phone number.
+You can create your own migration to add these fields (see: [an example migration](bin/20190603101528_alter_table_users.php).
+If you used `auth:publish` you can also add these fields to your `UserModel`'s `$allowedFields` property.

--- a/bin/20190603101528_alter_table_users.php
+++ b/bin/20190603101528_alter_table_users.php
@@ -5,10 +5,7 @@ use CodeIgniter\Database\Migration;
 class Migration_alter_table_users extends Migration
 {
 	public function up()
-	{
-		// get rid of generic "name" columnd
-		$this->forge->dropColumn('users', 'name');
-		
+	{		
 		// add new identity info
 		$fields = [
 			'firstname'      => ['type' => 'VARCHAR', 'constraint' => 63, 'after' => 'username'],
@@ -24,11 +21,5 @@ class Migration_alter_table_users extends Migration
 		$this->forge->dropColumn('users', 'firstname');
 		$this->forge->dropColumn('users', 'lastname');
 		$this->forge->dropColumn('users', 'phone');
-		
-		// add back original "name" field from Myth:Auth
-		$fields = [
-			'name' => ['type' => 'varchar', 'constraint' => 30, 'null' => true, 'after' => 'username'],
-		];
-		$this->forge->addColumn($fields);
 	}
 }

--- a/bin/20190603101528_alter_table_users.php
+++ b/bin/20190603101528_alter_table_users.php
@@ -1,0 +1,34 @@
+<?php namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class Migration_alter_table_users extends Migration
+{
+	public function up()
+	{
+		// get rid of generic "name" columnd
+		$this->forge->dropColumn('users', 'name');
+		
+		// add new identity info
+		$fields = [
+			'firstname'      => ['type' => 'VARCHAR', 'constraint' => 63, 'after' => 'username'],
+			'lastname'       => ['type' => 'VARCHAR', 'constraint' => 63, 'after' => 'firstname'],
+			'phone'          => ['type' => 'VARCHAR', 'constraint' => 63, 'after' => 'lastname'],
+		];
+		$this->forge->addColumn('users', $fields);
+	}
+
+	public function down()
+	{
+		// drop new columns
+		$this->forge->dropColumn('users', 'firstname');
+		$this->forge->dropColumn('users', 'lastname');
+		$this->forge->dropColumn('users', 'phone');
+		
+		// add back original "name" field from Myth:Auth
+		$fields = [
+			'name' => ['type' => 'varchar', 'constraint' => 30, 'null' => true, 'after' => 'username'],
+		];
+		$this->forge->addColumn($fields);
+	}
+}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -140,8 +140,6 @@ class AuthController extends Controller
         // Save the user
         $user = new User($this->request->getPost());
 
-        $user->name = $user->username;
-
         if (! $users->save($user))
         {
             return redirect()->back()->withInput()->with('errors', $users->errors());

--- a/src/Database/Migrations/20171120223112_create_auth_tables.php
+++ b/src/Database/Migrations/20171120223112_create_auth_tables.php
@@ -13,7 +13,6 @@ class Migration_create_auth_tables extends Migration
             'id'               => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
             'email'            => ['type' => 'varchar', 'constraint' => 255],
             'username'         => ['type' => 'varchar', 'constraint' => 30, 'null' => true],
-            'name'             => ['type' => 'varchar', 'constraint' => 30, 'null' => true],
             'password_hash'    => ['type' => 'varchar', 'constraint' => 255],
             'reset_hash'       => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
             'reset_time'       => ['type' => 'datetime', 'null' => true],

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -12,7 +12,7 @@ class UserModel extends Model
     protected $useSoftDeletes = true;
 
     protected $allowedFields = [
-        'email', 'username', 'name', 'password_hash', 'reset_hash', 'reset_start_time', 'activate_hash',
+        'email', 'username', 'password_hash', 'reset_hash', 'reset_start_time', 'activate_hash',
         'status', 'status_message', 'active', 'force_pass_reset', 'permissions', 'deleted',
     ];
 

--- a/tests/unit/DictionaryValidatorTest.php
+++ b/tests/unit/DictionaryValidatorTest.php
@@ -52,28 +52,6 @@ class DictionaryValidatorTest extends CIUnitTestCase
         $this->assertFalse($this->validator->check($password, $user));
     }
 
-    public function nameMatches()
-    {
-        return [
-            ['joe smith'],
-            ['joesmith'],
-            ['joe.smith'],
-            ['joe-smith']
-        ];
-    }
-
-    /**
-     * @dataProvider nameMatches
-     */
-    public function testCheckFalseOnNameMatch($passCheck)
-    {
-        $user = new \Myth\Auth\Entities\User([
-            'name' => 'Joe Smith'
-        ]);
-
-        $this->assertFalse($this->validator->check($passCheck, $user));
-    }
-
     public function testCheckFalseOnUsernameMatch()
     {
         $user = new \Myth\Auth\Entities\User([


### PR DESCRIPTION
As discussed in #44 it is preferable to leave off any unnecessary identity information so developers can use their own fields. Since `name` isn't currently in use this removes it form migrations, model, controller stub reference, and tests.