### PR TITLE
Add redirects to filters

### DIFF
--- a/src/Filters/LoginFilter.php
+++ b/src/Filters/LoginFilter.php
@@ -33,6 +33,8 @@ class LoginFilter implements FilterInterface
 		$authenticate = Services::authentication();
 		if (! $authenticate->check())
 		{
+			$session = session();
+			$session->set('redirect_url', current_url());
 			return redirect('login');
 		}
 	}

--- a/src/Filters/LoginFilter.php
+++ b/src/Filters/LoginFilter.php
@@ -33,8 +33,7 @@ class LoginFilter implements FilterInterface
 		$authenticate = Services::authentication();
 		if (! $authenticate->check())
 		{
-			$session = session();
-			$session->set('redirect_url', current_url());
+			session()->set('redirect_url', current_url());
 			return redirect('login');
 		}
 	}

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -33,8 +33,7 @@ class PermissionFilter implements FilterInterface
 		// if no user is logged in then send to the login form
         if (! $authenticate->check())
         {
-			$session = session();
-			$session->set('redirect_url', current_url());
+			session()->set('redirect_url', current_url());
             return redirect('login');
         }
 

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -33,6 +33,8 @@ class PermissionFilter implements FilterInterface
 		// if no user is logged in then send to the login form
         if (! $authenticate->check())
         {
+			$session = session();
+			$session->set('redirect_url', current_url());
             return redirect('login');
         }
 

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -33,8 +33,7 @@ class RoleFilter implements FilterInterface
 		// if no user is logged in then send to the login form
         if (! $authenticate->check())
         {
-			$session = session();
-			$session->set('redirect_url', current_url());
+			session()->set('redirect_url', current_url());
             return redirect('login');
         }
 

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -33,6 +33,8 @@ class RoleFilter implements FilterInterface
 		// if no user is logged in then send to the login form
         if (! $authenticate->check())
         {
+			$session = session();
+			$session->set('redirect_url', current_url());
             return redirect('login');
         }
 


### PR DESCRIPTION
Filters currently don't set `redirect_url` in session, so after login a user is returned to `/`. This change will use `current_url()` to send the user back to the requesting page.