### PR TITLE
Replace findWhere

### DIFF
--- a/src/Authorization/FlatAuthorization.php
+++ b/src/Authorization/FlatAuthorization.php
@@ -453,7 +453,7 @@ class FlatAuthorization implements AuthorizeInterface
             return $this->groupModel->find((int)$group);
         }
 
-        return $this->groupModel->findWhere('name', $group);
+        return $this->groupModel->where('name', $group)->first();
     }
 
     /**
@@ -558,7 +558,7 @@ class FlatAuthorization implements AuthorizeInterface
             return (int)$group;
         }
 
-        $g = $this->groupModel->findWhere('name', $group);
+        $g = $this->groupModel->where('name', $group)->first();
 
         if (! $g)
         {
@@ -588,7 +588,7 @@ class FlatAuthorization implements AuthorizeInterface
             return $this->permissionModel->find((int)$permission);
         }
 
-        return $this->permissionModel->findWhere('LOWER(name)', strtolower($permission));
+        return $this->permissionModel->where('LOWER(name)', strtolower($permission))->first();
     }
 
     /**

--- a/src/Authorization/GroupModel.php
+++ b/src/Authorization/GroupModel.php
@@ -7,6 +7,7 @@ class GroupModel extends Model
     protected $table = 'auth_groups';
     protected $primaryKey = 'id';
 
+    protected $returnType = 'object';
     protected $allowedFields = [
         'name', 'description'
     ];


### PR DESCRIPTION
`FlatAuthorization` still had a few references to the deprecated `findWhere`. This PR replaces them with `where()->first()`.