### PR TITLE
Change loginModel return type

### DIFF
--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -9,7 +9,7 @@ class LoginModel extends Model
     protected $table = 'auth_logins';
     protected $primaryKey = 'id';
 
-    protected $returnType = User::class;
+    protected $returnType = 'object';
     protected $useSoftDeletes = true;
 
     protected $allowedFields = [


### PR DESCRIPTION
I *think* this was a copy-paste error that `loginModel` was set to return User entities. This changes it to a generic object return.
