### PR TITLE
Change filters to use $params as array

### DIFF
--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -18,6 +18,7 @@ class PermissionFilter implements FilterInterface
      * redirects, etc.
      *
      * @param \CodeIgniter\HTTP\RequestInterface $request
+     * @param array|null                         $params
      *
      * @return mixed
      */
@@ -38,8 +39,15 @@ class PermissionFilter implements FilterInterface
         }
 
         $authorize = Services::authorization();
-
-        if (! $authorize->hasPermission($params, $authenticate->id()))
+		$result = true;
+		
+		// Check each requested permission
+		foreach ($params as $permission)
+		{
+			$result = $result && $authorize->hasPermission($permission, $authenticate->id());
+		}
+		
+        if (! $result)
         {
         	if ($authenticate->silent())
         	{

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -18,6 +18,7 @@ class RoleFilter implements FilterInterface
      * redirects, etc.
      *
      * @param \CodeIgniter\HTTP\RequestInterface $request
+     * @param array|null                         $params
      *
      * @return mixed
      */
@@ -38,8 +39,15 @@ class RoleFilter implements FilterInterface
         }
 
         $authorize = Services::authorization();
-
-        if (! $authorize->inGroup($params, $authenticate->id()))
+		$result = true;
+		
+		// Check each requested permission
+		foreach ($params as $group)
+		{
+			$result = $result && $authorize->inGroup($group, $authenticate->id());
+		}
+		
+        if (! $result)
         {
         	if ($authenticate->silent())
         	{


### PR DESCRIPTION
Current implementation expects a single string from `$params` but is actually being passed an array from CI4's `Filters->enableFilter`:
```
list($name, $params) = explode(':', $name);

$params = explode(',', $params);
array_walk($params, function (&$item) {
	$item = trim($item);
});

$this->arguments[$name] = $params;
```
This PR changes the two parameter-accepting filters to use `$params` as an array.

NOTE: Current implementation requires *all* permissions/roles to be fulfilled. Might consider these as *any* at some point, or additional filters so user may choose.
