### PR TITLE
Call user config class directly

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -21,7 +21,7 @@ class Services extends BaseService
 		// prioritizes user config in app/Config if found
 		if (class_exists('\Config\Auth'))
 		{
-			$config = config('Config\\Auth');
+			$config = new \Config\Auth();
 		}
 		else
 		{


### PR DESCRIPTION
I don't know why CI4's `config()` function is prioritizing the third-party file over the one in **app/Config**, but it is. This change corrects the issue, forcing the `authentication` service to load the user's config file (if found).
