### PR TITLE
AuthController implements user config

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -26,7 +26,15 @@ class AuthController extends Controller
         // the session to be started - so fire it up!
         $this->session = Services::session();
 
-        $this->config = config(Auth::class);
+		// prioritizes user config in app/Config if found
+		if (class_exists('\Config\Auth'))
+		{
+			$this->config = new \Config\Auth();
+		}
+		else
+		{
+			$this->config = config(Auth::class);
+		}
         $this->auth = Services::authentication();
     }
 


### PR DESCRIPTION
There are a few places that loaded the Myth config file directly. Probably need some better way of handling this centrally (like perhaps having them all call the service, which would need a `getConfig()` command?). For now this fixes AuthController to check for a user config file in order to use the `$allowRegistration` property properly.
