### PR TITLE
Leverage updated config() functionality

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -27,7 +27,7 @@ line and correct me. I'll make sure to read through it and try to correct either
 
 The included class, `Myth\Auth\Authentication\LocalAuthentication`, together with the `LoginModel` is the power 
 behind the features listed below. If you want to create your own, create a new class that implements the 
-`Myth\Auth\Authentication\AuthenticateInterface`. Then modify `application/Config/App.php` to use the new class. This 
+`Myth\Auth\Authentication\AuthenticateInterface`. Then modify `app/Config/App.php` to use the new class. This 
 will be automatically loaded up and readied for any class that uses the [Auth Trait](auth_trait.md).
 
 ## Logging Users In
@@ -119,7 +119,7 @@ You can have a user be remembered, through the user of cookies, by passing true 
 `attempt()` method, as described above. But what happens then? I have tried to make the process as secure as possible, 
 and will describe the process here so that you can understand the flow.
 
-If you do NOT want your users to be able to use persistent logins, you can turn this off in `application/Config/Auth.php`, 
+If you do NOT want your users to be able to use persistent logins, you can turn this off in `app/Config/Auth.php`, 
 along with a number of other settings. See the section on [Configuration](#configuration), below.
 
 ### Security Flow

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -18,15 +18,8 @@ class Services extends BaseService
             return self::getSharedInstance('authentication', $lib, $userModel, $loginModel);
         }
 		
-		// prioritizes user config in app/Config if found
-		if (class_exists('\Config\Auth'))
-		{
-			$config = new \Config\Auth();
-		}
-		else
-		{
-			$config = config(Auth::class);
-		}
+		// config() checks first in app/Config
+		$config = config('Auth');
 
         $class = $config->authenticationLibs[$lib];
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\Controller;
 use Config\Email;
-use Myth\Auth\Config\Auth;
 use Myth\Auth\Config\Services;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
@@ -26,7 +25,7 @@ class AuthController extends Controller
         // the session to be started - so fire it up!
         $this->session = Services::session();
 
-        $this->config = config(Auth::class);
+        $this->config = config('Auth');
         $this->auth = Services::authentication();
     }
 

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Entities;
 
 use CodeIgniter\Entity;
-use Myth\Auth\Config\Auth;
 
 class User extends Entity
 {
@@ -40,7 +39,7 @@ class User extends Entity
 	 */
 	public function setPassword(string $password)
 	{
-        $config = config(Auth::class);
+        $config = config('Auth');
 
 		$this->attributes['password_hash'] = password_hash(
 			base64_encode(

--- a/src/Exceptions/AuthException.php
+++ b/src/Exceptions/AuthException.php
@@ -1,7 +1,5 @@
 <?php namespace Myth\Auth\Exceptions;
 
-use Myth\Auth\Config\Auth;
-
 class AuthException extends \DomainException implements ExceptionInterface
 {
     public static function forInvalidModel(string $model)

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Models;
 
 use CodeIgniter\Model;
-use Myth\Auth\Config\Auth;
 use Myth\Auth\Entities\User;
 
 class LoginModel extends Model
@@ -99,7 +98,7 @@ class LoginModel extends Model
      */
     public function purgeOldRememberTokens()
     {
-        $config = config(Auth::class);
+        $config = config('Auth');
 
         if (! $config->allowRemembering)
         {


### PR DESCRIPTION
CI4's updated `config()` command will take an un-namespaced string and match the first config file from: App, System, modules. Since this is the desired behavior for **Config\Auth.php** I've replaced all references to `config(Auth::class)` with `config('Auth')` and removed unnecessary `use` statements.
