### PR TITLE
Reset force-pass-reset when password's changed

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -48,6 +48,9 @@ class User extends Entity
 			PASSWORD_DEFAULT,
 			['cost' => $config->hashCost]
 		);
+
+        // Reset force_password_reset
+        $this->attributes['force_pass_reset'] = 0;
 	}
 
     /**

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -41,14 +41,29 @@ class User extends Entity
 	{
         $config = config('Auth');
 
-		$this->attributes['password_hash'] = password_hash(
-			base64_encode(
-				hash('sha384', $password, true)
-			),
-			PASSWORD_DEFAULT,
-			['cost' => $config->hashCost]
-		);
+        if($config->hashAlgorithm == PASSWORD_ARGON2I)
+        {
+            $hashOptions = [
+                'memory_cost' => $config->hashMemoryCost,
+                'time_cost'   => $config->hashTimeCost,
+                'threads'     => $config->hashThreads
+                ];
+        }
+        else
+        {
+            $hashOptions = [
+                'cost' => $config->hashCost
+                ];
+        }
 
+        $this->attributes['password_hash'] = password_hash(
+            base64_encode(
+                hash('sha384', $password, true)
+            ),
+            $config->hashAlgorithm,
+            $hashOptions
+        );
+        
         // Reset force_password_reset
         $this->attributes['force_pass_reset'] = 0;
 	}

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -63,9 +63,6 @@ class User extends Entity
             $config->hashAlgorithm,
             $hashOptions
         );
-        
-        // Reset force_password_reset
-        $this->attributes['force_pass_reset'] = 0;
 	}
 
     /**


### PR DESCRIPTION
If it's set it is supposed to force user to change his password.
But once pwd's changed, force-pass-reset maintains the same value.
With this change, value is reset to 0 after a successful pwd change