### PR TITLE
Multiple hashing algorithm option

### DIFF
--- a/src/Authentication/LocalAuthenticator.php
+++ b/src/Authentication/LocalAuthenticator.php
@@ -141,7 +141,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
         // This would be due to the hash algorithm or hash
         // cost changing since the last time that a user
         // logged in.
-        if (password_needs_rehash($user->password_hash, PASSWORD_DEFAULT))
+        if (password_needs_rehash($user->password_hash, $this->config->hashAlgorithm))
         {
             $user->password = $password;
             $this->userModel->save($user);

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -69,6 +69,23 @@ class Auth extends BaseConfig
     //
     public $silent = false;
 
+    // Valid values are PASSWORD_DEFAULT, PASSWORD_BCRYPT and PASSWORD_ARGON2I.
+    public $hashAlgorithm = PASSWORD_ARGON2I;
+
+    //--------------------------------------------------------------------
+    // ARGON2i Algorithm options
+    //--------------------------------------------------------------------
+    // The ARGON2I method of encryption allows you to define the "memory_cost",
+    // the "time_cost" and the number of "threads", whenever a password hash is created.
+    // This defaults to a value of 10 which is an acceptable number.
+    // However, depending on the security needs of your application
+    // and the power of your hardware, you might want to increase the
+    // cost. This makes the hashing process takes longer.
+    //
+    public $hashMemoryCost = PASSWORD_ARGON2_DEFAULT_MEMORY_COST;  // 1024
+    public $hashTimeCost = PASSWORD_ARGON2_DEFAULT_TIME_COST;      // 2
+    public $hashThreads = PASSWORD_ARGON2_DEFAULT_THREADS;         // 2
+
     //--------------------------------------------------------------------
     // Password Hashing Cost
     //--------------------------------------------------------------------

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -41,13 +41,28 @@ class User extends Entity
 	{
         $config = config('Auth');
 
-		$this->attributes['password_hash'] = password_hash(
-			base64_encode(
-				hash('sha384', $password, true)
-			),
-			PASSWORD_DEFAULT,
-			['cost' => $config->hashCost]
-		);
+        if($config->hashAlgorithm == PASSWORD_ARGON2I)
+        {
+            $hashOptions = [
+                'memory_cost' => $config->hashMemoryCost,
+                'time_cost'   => $config->hashTimeCost,
+                'threads'     => $config->hashThreads
+                ];
+        }
+        else
+        {
+            $hashOptions = [
+                'cost' => $config->hashCost
+                ];
+        }
+
+        $this->attributes['password_hash'] = password_hash(
+            base64_encode(
+                hash('sha384', $password, true)
+            ),
+            $config->hashAlgorithm,
+            $hashOptions
+        );
 	}
 
     /**


### PR DESCRIPTION
Added option in auth config to select which kind of algorithm to use.
Both default and bcrypt algorithms use cost parameter which was already configurable.
Argon2i has other options, with are set to defaults in config file, but are checked in Entity::User in the setPassword method.
Password_needs_rehash method in LocalAuthenticator behaved correctly when config algorithm option was changed, updating the user's password correctly on first login -after the config change-.