### PR TITLE
Fixes #64 inGroup method to check with OR instead of AND

### DIFF
--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -39,12 +39,15 @@ class RoleFilter implements FilterInterface
         }
 
         $authorize = Services::authorization();
-		$result = true;
+		$result = false;
 		
 		// Check each requested permission
 		foreach ($params as $group)
 		{
-			$result = $result && $authorize->inGroup($group, $authenticate->id());
+            if(! $result)
+            {
+                $result = $authorize->inGroup($group, $authenticate->id());
+            }
 		}
 		
         if (! $result)

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -39,30 +39,25 @@ class RoleFilter implements FilterInterface
         }
 
         $authorize = Services::authorization();
-		$result = false;
 		
 		// Check each requested permission
 		foreach ($params as $group)
 		{
-            if(! $result)
+            if($authorize->inGroup($group, $authenticate->id()))
             {
-                $result = $authorize->inGroup($group, $authenticate->id());
+                return;
             }
-            else return;
 		}
 		
-        if (! $result)
-        {
-        	if ($authenticate->silent())
-        	{
-				$redirectURL = session('redirect_url') ?? '/';
-				unset($_SESSION['redirect_url']);
-				return redirect()->to($redirectURL)->with('error', lang('Auth.notEnoughPrivilege'));
-        	}
-        	else {
-        		throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
-        	}
-        }
+    	if ($authenticate->silent())
+    	{
+			$redirectURL = session('redirect_url') ?? '/';
+			unset($_SESSION['redirect_url']);
+			return redirect()->to($redirectURL)->with('error', lang('Auth.notEnoughPrivilege'));
+    	}
+    	else {
+    		throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
+    	}
     }
 
     //--------------------------------------------------------------------

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -48,6 +48,7 @@ class RoleFilter implements FilterInterface
             {
                 $result = $authorize->inGroup($group, $authenticate->id());
             }
+            else return;
 		}
 		
         if (! $result)


### PR DESCRIPTION
Rolefilter method ```inGroup()``` used to do an ```AND``` comparison to check if user belonged to all groups.
Now, it's changed to an ```OR``` comparison, ie: if user belongs to any group passed as parameters, then it returns ```TRUE```.
Regarding the ```AND```check, if needed it could be in a new method named ```inGroups()``` that would make more sense