### PR TITLE
Added defined('PASSWORD_ARGON2I') to condition check in user entity

### DIFF
--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -69,22 +69,35 @@ class Auth extends BaseConfig
     //
     public $silent = false;
 
-    // Valid values are PASSWORD_DEFAULT, PASSWORD_BCRYPT and PASSWORD_ARGON2I.
-    public $hashAlgorithm = PASSWORD_ARGON2I;
+    /*--------------------------------------------------------------------
+	 * Encryption Algorithm to use
+	 *--------------------------------------------------------------------
+	 * Valid values are
+	 * - PASSWORD_DEFAULT (default)
+	 * - PASSWORD_BCRYPT
+	 * - PASSWORD_ARGON2I  - As of PHP 7.2 only if compiled with support for it
+	 * - PASSWORD_ARGON2ID - As of PHP 7.3 only if compiled with support for it
+	 *
+	 * If you choose to use any ARGON algorithm, then you might want to
+	 * uncomment the "ARGON2i/D Algorithm" options to suit your needs
+     */
+	public $hashAlgorithm = PASSWORD_DEFAULT;
 
-    //--------------------------------------------------------------------
-    // ARGON2i Algorithm options
-    //--------------------------------------------------------------------
-    // The ARGON2I method of encryption allows you to define the "memory_cost",
-    // the "time_cost" and the number of "threads", whenever a password hash is created.
-    // This defaults to a value of 10 which is an acceptable number.
-    // However, depending on the security needs of your application
-    // and the power of your hardware, you might want to increase the
-    // cost. This makes the hashing process takes longer.
-    //
-    public $hashMemoryCost = PASSWORD_ARGON2_DEFAULT_MEMORY_COST;  // 1024
-    public $hashTimeCost = PASSWORD_ARGON2_DEFAULT_TIME_COST;      // 2
-    public $hashThreads = PASSWORD_ARGON2_DEFAULT_THREADS;         // 2
+	/*--------------------------------------------------------------------
+	 * ARGON2i/D Algorithm options
+	 *--------------------------------------------------------------------
+     * The ARGON2I method of encryption allows you to define the "memory_cost",
+     * the "time_cost" and the number of "threads", whenever a password hash is
+     * created.
+     * This defaults to a value of 10 which is an acceptable number.
+     * However, depending on the security needs of your application
+     * and the power of your hardware, you might want to increase the
+     * cost. This makes the hashing process takes longer.
+     */
+
+	public $hashMemoryCost = 2048; 	//PASSWORD_ARGON2_DEFAULT_MEMORY_COST;
+	public $hashTimeCost = 4; 		//PASSWORD_ARGON2_DEFAULT_TIME_COST;
+	public $hashThreads = 4; 		//PASSWORD_ARGON2_DEFAULT_THREADS;
 
     //--------------------------------------------------------------------
     // Password Hashing Cost

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -41,7 +41,11 @@ class User extends Entity
 	{
         $config = config('Auth');
 
-        if($config->hashAlgorithm == PASSWORD_ARGON2I)
+        if (
+            (defined('PASSWORD_ARGON2I') && $config->hashAlgorithm == PASSWORD_ARGON2I)
+                ||
+            (defined('PASSWORD_ARGON2ID') && $config->hashAlgorithm == PASSWORD_ARGON2ID)
+            )
         {
             $hashOptions = [
                 'memory_cost' => $config->hashMemoryCost,


### PR DESCRIPTION
It wouldn't work as I wasn't using ' surrounding the constant name inside define()