### PR TITLE
Fix table name in down()

### DIFF
--- a/src/Database/Migrations/20171120223112_create_auth_tables.php
+++ b/src/Database/Migrations/20171120223112_create_auth_tables.php
@@ -166,7 +166,7 @@ class Migration_create_auth_tables extends Migration
         }
 
 		$this->forge->dropTable('users', true);
-		$this->forge->dropTable('auth_login', true);
+		$this->forge->dropTable('auth_logins', true);
 		$this->forge->dropTable('auth_tokens', true);
 		$this->forge->dropTable('auth_reset_attempts', true);
 		$this->forge->dropTable('auth_groups', true);


### PR DESCRIPTION
There appears to be a legacy table name `auth_login_attempts` in the `down()` migration that is blocking `Migrations->refresh()` from working since the table is never dropped.