### PR TITLE
Fixes #90 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "minimum-stability": "dev",
   "require-dev": {
-    "phpunit/phpunit" : "^7.0",
+    "phpunit/phpunit" : "^7.1",
     "mockery/mockery": "^1.0",
     "codeigniter4/codeigniter4": "dev-develop"
   },

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -67,6 +67,19 @@ class User extends Entity
             $config->hashAlgorithm,
             $hashOptions
         );
+
+        /*
+            Set these vars to null in case a reset password was asked.
+            Scenario:
+                user (a *dumb* one with short memory) requests a 
+                reset-token and then does nothing => asks the
+                administrator to reset his password.
+            User would have a new password but still anyone with the
+            reset-token would be able to change the password.
+        */
+        $this->attributes['reset_hash'] = null;
+        $this->attributes['reset_time'] = null;
+        $this->attributes['reset_start_time'] = null;
 	}
 
     /**

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -79,7 +79,7 @@ class User extends Entity
         */
         $this->attributes['reset_hash'] = null;
         $this->attributes['reset_time'] = null;
-        $this->attributes['reset_start_time'] = null;
+        // $this->attributes['reset_start_time'] = null;
 	}
 
     /**


### PR DESCRIPTION
After hashing and assigning the new password to user, reset vars in user entity get nullified.
```
        /*
            Set these vars to null in case a reset password was asked.
            Scenario:
                user (a *dumb* one with short memory) requests a
                reset-token and then does nothing => asks the
                administrator to reset his password.
            User would have a new password but still anyone with the
            reset-token would be able to change the password.
        */
        $this->attributes['reset_hash'] = null;
        $this->attributes['reset_time'] = null;
        $this->attributes['reset_start_time'] = null;
```