### PR TITLE
Fix validation rule bug for registration

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -144,7 +144,8 @@ class AuthController extends Controller
 
 		// Validate here first, since some things,
 		// like the password, can only be validated properly here.
-		$rules = array_merge($users->getValidationRules(['only' => ['email', 'username']]), [
+		$rules = array_merge($users->getValidationRules(['only' => ['username']]), [
+			'email'		=> 'required|valid_email|is_unique[users.email]',
 			'password'	 => 'required|strong_password',
 			'pass_confirm' => 'required|matches[password]',
 		]);


### PR DESCRIPTION
When we try to register a user using PostgreSQL, we receive an error:

```php
pg_query(): Query failed: ERROR: invalid input syntax for integer: "{id}" LINE 4: AND "id" != '{id}'
```

This wasn't popping up when using MySQL, because PostgreSQL is more restrictive. So, running the query:
```sql
SELECT 1 FROM "users" WHERE "email" = 'test@email.local' AND "id" != '{id}' LIMIT 1
```

is fine on mysql but not really on postgresql. But in both cases, it's a bug actually.

The fix comes down to changing the validation rules for registration.