### PR TITLE
Add PwnedValidator

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -213,10 +213,15 @@ in succession. You can easily add your own should you need to customize the vali
     public $passwordValidators = [
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
         'Myth\Auth\Authentication\Passwords\DictionaryValidator',
+        //'Myth\Auth\Authentication\Passwords\PwnedValidator',
     ];
 
 The default validators that come with Myth:Auth are:
 
 - CompositionValidator - per the latest NIST recommendations, simply checks password length.
 - DictionaryValidator - compares the password with over 600,000 leaked passwords and common words, as well as
-    variations on the user's personal info, like name and email. 
+    variations on the user's personal info, like name and email.
+- PwnedValidator - compares the password with over half a billion of real-world passwords previously exposed in data breaches. 
+    It uses a request to third-party API. This validator is optional and disabled by default since not everyone may be 
+    comfortable with using it. The decision to use it or not is up to you - more information and technical details can 
+    be found [here](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity).

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -65,14 +65,7 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
 
         $response = $client->get('range/' . $rangeHash, ['headers' => ['Accept' => 'text/plain']]);
 
-        $body = $response->getBody();
-
-        if (strpos($body, ':') === false)
-        {
-            return true;
-        }
-
-        foreach (explode("\r\n", $body) as $line)
+        foreach (explode("\r\n", $response->getBody()) as $line)
         {
             list($hash, $hits) = explode(':', $line);
 

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -1,0 +1,113 @@
+<?php namespace Myth\Auth\Authentication\Passwords;
+
+use CodeIgniter\Entity;
+use CodeIgniter\Config\Services;
+use Myth\Auth\Exceptions\AuthException;
+
+/**
+ * Class PwnedValidator
+ *
+ * Checks if the password has been compromised.
+ *
+ * NIST recommend to check passwords against those obtained from previous data breaches.
+ *
+ * @see https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/
+ * @see https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
+ *
+ * @package Myth\Auth\Authentication\Passwords\Validators
+ */
+class PwnedValidator extends BaseValidator implements ValidatorInterface
+{
+    /**
+     * Error message.
+     *
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * Suggestion message.
+     *
+     * @var string
+     */
+    protected $suggestion;
+
+    /**
+     * Checks the password and returns true/false
+     * if it passes muster. Must return either true/false.
+     * True means the password passes this test and
+     * the password will be passed to any remaining validators.
+     * False will immediately stop validation process
+     *
+     * @param string $password
+     * @param Entity $user
+     *
+     * @return bool
+     */
+    public function check(string $password, Entity $user = null): bool
+    {
+        $password = trim($password);
+
+        if (empty($password))
+        {
+            $this->error = lang('Auth.errorPasswordEmpty');
+
+            return false;
+        }
+
+        $password   = strtoupper(sha1($password));
+        $rangeHash  = substr($password, 0, 5);
+        $searchHash = substr($password, 5);
+
+        $client = Services::curlrequest([
+            'base_uri' => 'https://api.pwnedpasswords.com/',
+        ]);
+
+        $response = $client->get('range/' . $rangeHash, ['headers' => ['Accept' => 'text/plain']]);
+
+        $body = $response->getBody();
+
+        if (strpos($body, ':') === false)
+        {
+            return true;
+        }
+
+        foreach (explode("\r\n", $body) as $line)
+        {
+            list($hash, $hits) = explode(':', $line);
+
+            if ($hash === $searchHash)
+            {
+                $this->error = lang('Auth.errorPasswordPwned', [(int) $hits]);
+                $this->suggestion = lang('Auth.suggestPasswordPwned');
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the error string that should be displayed to the user.
+     *
+     * @return string
+     */
+    public function error(): string
+    {
+        return $this->error;
+    }
+
+    /**
+     * Returns a suggestion that may be displayed to the user
+     * to help them choose a better password. The method is
+     * required, but a suggestion is optional. May return
+     * an empty string instead.
+     *
+     * @return string
+     */
+    public function suggestion(): string
+    {
+        return $this->suggestion;
+    }
+}

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -131,6 +131,7 @@ class Auth extends BaseConfig
     public $passwordValidators = [
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
         'Myth\Auth\Authentication\Passwords\DictionaryValidator',
+        'Myth\Auth\Authentication\Passwords\PwnedValidator',
     ];
 
     //--------------------------------------------------------------------

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -131,7 +131,7 @@ class Auth extends BaseConfig
     public $passwordValidators = [
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
         'Myth\Auth\Authentication\Passwords\DictionaryValidator',
-        'Myth\Auth\Authentication\Passwords\PwnedValidator',
+        //'Myth\Auth\Authentication\Passwords\PwnedValidator',
     ];
 
     //--------------------------------------------------------------------

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -33,6 +33,8 @@ return [
     'suggestPasswordCommon'     => 'The password was checked against over 65k commonly used passwords or passwords that have been leaked through hacks.',
     'errorPasswordPersonal'     => 'Passwords cannot contain re-hashed personal information.',
     'suggestPasswordPersonal'   => 'Variations on your email address or username should not be used for passwords.',
+    'errorPasswordPwned'        => 'This password has been seen {0, number} times before. It was found in a database of compromised passwords.',
+    'suggestPasswordPwned'      => 'This password has previously appeared in a data breach and should never be used. If you\'ve used it anywhere before, change it immediately.',
     'errorPasswordEmpty'        => 'Passwords are required.',
     'passwordChangeSuccess'     => 'Password changed successfully',
     'userDoesNotExist'          => 'Password was not changed. User does not exist',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -33,6 +33,8 @@ return [
     'suggestPasswordCommon'     => 'La contraseña fue contrastada contra 65.000 de uso habitual y las que fueron hackeadas.',
     'errorPasswordPersonal'     => 'Las contraseñas no pueden contener información personal.',
     'suggestPasswordPersonal'   => 'Variaciones de su e-mail o usuario no deben usarse como contraseñas.',
+    'errorPasswordPwned'        => 'This password has been seen {0, number} times before. It was found in a database of compromised passwords.', // translate
+    'suggestPasswordPwned'      => 'This password has previously appeared in a data breach and should never be used. If you\'ve used it anywhere before, change it immediately.', // translate
     'errorPasswordEmpty'        => 'Se requiere una contraseña.',
     'passwordChangeSuccess'     => 'Contraseña cambiada',
     'userDoesNotExist'          => 'No se cambió la contraseña. El usuario no existe',

--- a/tests/unit/PwnedValidatorTest.php
+++ b/tests/unit/PwnedValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Myth\Auth\Config\Services;
+use Config\App;
+use CodeIgniter\HTTP\Response;
+use CodeIgniter\Test\CIUnitTestCase;
+use Myth\Auth\Authentication\Passwords\PwnedValidator;
+
+class PwnedValidatorTest extends CIUnitTestCase
+{
+    /**
+     * @var CompositionValidator
+     */
+    protected $validator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Services::reset();
+
+        $this->validator = new PwnedValidator();
+    }
+
+    public function testCheckFalseOnEmptyPassword()
+    {
+        $password = '';
+
+        $this->assertFalse($this->validator->check($password));
+    }
+
+    public function testCheckFalseOnPwnedPassword()
+    {
+        $body = implode("\r\n", ['52D9BC2F7F8F471B3192A0D1FF53F7A103D:2', '52EAAD4687FABF36801DF580FB497C6CECA:1', '53623B121FD34EE5426C792E5C33AF8C227:50329', '538F23AA21F516E4767380DE4AB7D30AF9B:2', '5421C6ECD4AF2B65598980DDC3BC164ED4B:9', '54355ADA7D7B306C68DAC1548E84B53A10F:1']);
+
+        $response  = new Response(new App());
+        $response->setBody($body);
+
+        $curlrequest = $this->getMockBuilder('CodeIgniter\HTTP\CURLRequest')
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        $curlrequest->method('get')->willReturn($response);
+
+        Services::injectMock('curlrequest', $curlrequest);
+
+        $password = 'admin123';
+
+        $this->assertFalse($this->validator->check($password));
+    }
+
+    public function testCheckTrueOnNotFound()
+    {
+        $body = implode("\r\n", ['02AEBBE44887FF9D7BCCB8437910EB92DE8:1', 'n02EE34E878ABDBFBD2439BC799F85869521:1', '033C5EE74BC4C953E2972C7D87BB1858A85:2', '0385DB23CA0658858A494B66A7933955551:1', '03B14A9EA4D383220176FDC3B3BC771A415:1', '03BE55564E0C24C43E416F595B743588A27:1']);
+        
+        $response  = new Response(new App());
+        $response->setBody($body);
+
+        $curlrequest = $this->getMockBuilder('CodeIgniter\HTTP\CURLRequest')
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        $curlrequest->method('get')->willReturn($response);
+
+        Services::injectMock('curlrequest', $curlrequest);
+
+        $password = '!!!gerard!!!abootylicious';
+
+        $this->assertTrue($this->validator->check($password));
+    }
+
+}


### PR DESCRIPTION
This pull request adds an additional check for passwords against Pwned database.

This is the biggest database of compromised passwords completed from many data breaches: https://haveibeenpwned.com/Passwords

We use their API and since they're supported by Cloudflare the data are cached and delivered quickly. There is no need for an API key.

Personally, I think it would be a good addition and users could be informed about additional threats that relate to the passwords they choose.

Further read: https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity