### PR TITLE
Check for allowRemembering in view

### DIFF
--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -41,12 +41,14 @@
 							</div>
 						</div>
 
+<?php if ($config->allowRemembering): ?>
 						<div class="form-check">
 							<label class="form-check-label">
 								<input type="checkbox" name="remember" class="form-check-input" <?php if(old('remember')) : ?> checked <?php endif ?>>
 								<?=lang('Auth.rememberMe')?>
 							</label>
 						</div>
+<?php endif; ?>
 
 						<br>
 


### PR DESCRIPTION
Display "Remember me" checkbox only when `allowRemembering` config variable is enabled.