### PR TITLE
Fix user entity permissions

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -155,8 +155,8 @@ class User extends Entity
      */
     public function getPermissions()
     {
-        return ! empty($this->permissions)
-            ? json_decode($this->permissions, true)
+        return ! empty($this->attributes['permissions'])
+            ? json_decode($this->attributes['permissions'], true)
             : [];
 	}
 
@@ -172,7 +172,7 @@ class User extends Entity
     {
         if (is_array($permissions))
         {
-            $this->permissions = json_encode($permissions);
+            $this->attributes['permissions'] = json_encode($permissions);
         }
 
         return $this;

--- a/tests/unit/UserEntityTest.php
+++ b/tests/unit/UserEntityTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Myth\Auth\Entities\User;
+use CodeIgniter\Test\CIUnitTestCase;
+
+class UserEntityTest extends CIUnitTestCase
+{
+    /**
+     * @var User
+     */
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new User(['username' => 'conscious4u', 'email' => 'jiminy.cricket@example.com']);
+    }
+    
+	public function testGetSetPermissions()
+	{
+		$this->assertEmpty($this->user->getPermissions());
+		
+		$permissions = [1, 2, 4, 5];
+		$this->user->setPermissions($permissions);
+
+		$this->assertEquals($permissions, $this->user->getPermissions());
+	}
+}


### PR DESCRIPTION
Updates `User` entity to use attributes correctly when set/get permissions. Adds a test for the entity (missing lots of tests but it's a start).

Fix for https://github.com/lonnieezell/myth-auth/issues/106