### PR TITLE
Proposal - confirm registration (optional)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -160,6 +160,20 @@ The only parameter is the email of the user.
 
 	$auth->purgeLoginAttempts($email);
 
+## User account activation
+
+After the user has registered in our app, we have the option to activate the account immediately or ask for confirmation.
+This is done via `$requireActivation` config variable.
+
+Confirmation can be done in many ways. Traditionally, this is usually done by sending an email to the email address that was
+used during registration. We use the `Activator` service for this.
+
+	$activator = Services::activator();
+	$activator->send($user);
+
+By default, we provide one type of activator and this is `EmailActivator`. You can also prepare your own activator,
+which will e.g. use an SMS to confirm activation. There are many possibilities.
+
 ## Configuration
 Many aspects of the system can be configured in the `Config/Auth.php` config file. These options are described here. 
 
@@ -181,6 +195,23 @@ The names of the fields in the user table that are allowed by used when testing 
 This can be either true or false, and determines whether or not the system allows unregistered users to make a new
 account by accessing `AuthController->register()`. NOTE: This setting is not enforced by `UserModel` so if you add
 or edit controller and views you are responsible for checking this value.
+
+### auth.requireActivation
+This can be either false or string with a namespaced class name. Using a class name will force `activator` service to use this
+class to send an activation message.
+
+	public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
+
+### auth.userActivators
+This is a list of available activators, along with their optional configuration variables. Class names listed here can be used
+by `requireActivation` config variable.
+
+	public $userActivators = [
+        'Myth\Auth\Authentication\Activators\EmailActivator' => [
+            'fromEmail' => null,
+            'fromName' => null,
+        ],
+    ];
 
 ### auth.allowRemembering
 This can be either true or false, and determines whether or not the system allows persistent logins (Remember Me). 

--- a/src/Authentication/Activators/ActivatorInterface.php
+++ b/src/Authentication/Activators/ActivatorInterface.php
@@ -1,0 +1,28 @@
+<?php namespace Myth\Auth\Authentication\Activators;
+
+use CodeIgniter\Entity;
+
+/**
+ * Interface ActivatorInterface
+ *
+ * @package Myth\Auth\Authentication\Activators
+ */
+interface ActivatorInterface
+{
+    /**
+     * Send activation message to user
+     *
+     * @param User $user
+     *
+     * @return mixed
+     */
+    public function send(Entity $user = null): bool;
+
+    /**
+     * Returns the error string that should be displayed to the user.
+     *
+     * @return string
+     */
+    public function error(): string;
+
+}

--- a/src/Authentication/Activators/BaseActivator.php
+++ b/src/Authentication/Activators/BaseActivator.php
@@ -1,0 +1,31 @@
+<?php namespace Myth\Auth\Authentication\Activators;
+
+class BaseActivator
+{
+    protected $config;
+
+    /**
+     * Allows for setting a config file on the Activator.
+     *
+     * @param $config
+     *
+     * @return $this
+     */
+    public function setConfig($config)
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * Gets a config settings for current Activator.
+     *
+     * @return $array
+     */
+    public function getActivatorSettings()
+    {
+        return (object) $this->config->userActivators[get_class($this)];
+    }
+
+}

--- a/src/Authentication/Activators/EmailActivator.php
+++ b/src/Authentication/Activators/EmailActivator.php
@@ -1,0 +1,61 @@
+<?php namespace Myth\Auth\Authentication\Activators;
+
+use Config\Email;
+use CodeIgniter\Entity;
+use CodeIgniter\Config\Services;
+
+/**
+ * Class EmailActivator
+ *
+ * Sends an activation email to user.
+ *
+ * @package Myth\Auth\Authentication\Activators
+ */
+class EmailActivator extends BaseActivator implements ActivatorInterface
+{
+    /**
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * Sends an activation email
+     *
+     * @param User $user
+     *
+     * @return mixed
+     */
+    public function send(Entity $user = null): bool
+    {
+        $email = Services::email();
+        $config = new Email();
+
+        $settings = $this->getActivatorSettings();
+
+        $sent = $email->setFrom($settings->fromEmail ?? $config->fromEmail, $settings->fromName ?? $config->fromName)
+              ->setTo($user->email)
+              ->setSubject(lang('Auth.activationSubject'))
+              ->setMessage(view($this->config->views['emailActivation'], ['hash' => $user->activate_hash]))
+              ->setMailType('html')
+              ->send();
+
+        if (! $sent)
+        {
+            $this->error = lang('Auth.errorSendingActivation', [$user->email]);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the error string that should be displayed to the user.
+     *
+     * @return string
+     */
+    public function error(): string
+    {
+        return $this->error ?? '';
+    }
+
+}

--- a/src/Authentication/Activators/UserActivator.php
+++ b/src/Authentication/Activators/UserActivator.php
@@ -1,0 +1,65 @@
+<?php namespace Myth\Auth\Authentication\Activators;
+
+use Myth\Auth\Config\Auth;
+use Myth\Auth\Entities\User;
+
+class UserActivator
+{
+    /**
+     * @var Auth
+     */
+    protected $config;
+
+    protected $error;
+
+    public function __construct(Auth $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Sends activation message to the user via specified class
+     * in `$requireActivation` setting in Config\Auth.php.
+     *
+     * @param User $user
+     *
+     * @return bool
+     */
+    public function send(User $user = null): bool
+    {
+        $result = false;
+
+        if ($this->config->requireActivation === false)
+        {
+            return $result;
+        }
+
+        $className = $this->config->requireActivation;
+
+        $class = new $className();
+        $class->setConfig($this->config);
+
+        if ($class->send($user) === false)
+        {
+            log_message('error', "Failed to send activation messaage to: {$user->email}");
+            $this->error = $class->error();
+        }
+        else
+        {
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns the current error.
+     *
+     * @return mixed
+     */
+    public function error()
+    {
+        return $this->error;
+    }
+
+}

--- a/src/Authentication/Activators/UserActivator.php
+++ b/src/Authentication/Activators/UserActivator.php
@@ -27,11 +27,9 @@ class UserActivator
      */
     public function send(User $user = null): bool
     {
-        $result = false;
-
         if ($this->config->requireActivation === false)
         {
-            return $result;
+            return true;
         }
 
         $className = $this->config->requireActivation;
@@ -43,13 +41,11 @@ class UserActivator
         {
             log_message('error', "Failed to send activation messaage to: {$user->email}");
             $this->error = $class->error();
-        }
-        else
-        {
-            $result = true;
+
+            return false;
         }
 
-        return $result;
+        return true;
     }
 
     /**

--- a/src/Authentication/LocalAuthenticator.php
+++ b/src/Authentication/LocalAuthenticator.php
@@ -38,6 +38,18 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
             return false;
         }
 
+        if (! $this->user->isActivated())
+        {
+            // Always record a login attempt, whether success or not.
+            $ipAddress = Services::request()->getIPAddress();
+            $this->recordLoginAttempt($credentials['email'] ?? $credentials['username'], $ipAddress, $this->user->id ?? null, false);
+
+            $this->error = lang('Auth.notActivated');
+
+            $this->user = null;
+            return false;
+        }
+
         return $this->login($this->user, $remember);
     }
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -50,7 +50,7 @@ class Auth extends BaseConfig
     // When enabled, every registered user will receive an email message
     // with a special link he have to confirm to activate his account.
     //
-    public $requireActivation = true;
+    public $requireActivation = false;
 
     //--------------------------------------------------------------------
     // Allow Persistent Login Cookies (Remember me)

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -23,6 +23,7 @@ class Auth extends BaseConfig
         'forgot'    => 'Myth\Auth\Views\forgot',
         'reset'     => 'Myth\Auth\Views\reset',
         'emailForgot' => 'Myth\Auth\Views\emails\forgot',
+        'emailActivation' => 'Myth\Auth\Views\emails\activation',
     ];
 
     //--------------------------------------------------------------------
@@ -42,6 +43,14 @@ class Auth extends BaseConfig
     // controllers and views know not to offer registration.
     //
     public $allowRegistration = true;
+
+    //--------------------------------------------------------------------
+    // Require confirmation registration via email
+    //--------------------------------------------------------------------
+    // When enabled, every registered user will receive an email message
+    // with a special link he have to confirm to activate his account.
+    //
+    public $requireActivation = true;
 
     //--------------------------------------------------------------------
     // Allow Persistent Login Cookies (Remember me)

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -50,7 +50,7 @@ class Auth extends BaseConfig
     // When enabled, every registered user will receive an email message
     // with a special link he have to confirm to activate his account.
     //
-    public $requireActivation = false;
+    public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
 
     //--------------------------------------------------------------------
     // Allow Persistent Login Cookies (Remember me)
@@ -141,6 +141,18 @@ class Auth extends BaseConfig
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
         'Myth\Auth\Authentication\Passwords\DictionaryValidator',
         //'Myth\Auth\Authentication\Passwords\PwnedValidator',
+    ];
+
+    //--------------------------------------------------------------------
+    // Activator classes
+    //--------------------------------------------------------------------
+    // Avaliable activators with config settings
+    //
+    public $userActivators = [
+        'Myth\Auth\Authentication\Activators\EmailActivator' => [
+            'fromEmail' => null,
+            'fromName' => null,
+        ],
     ];
 
     //--------------------------------------------------------------------

--- a/src/Config/Routes.php
+++ b/src/Config/Routes.php
@@ -14,6 +14,9 @@ $routes->group('', ['namespace' => 'Myth\Auth\Controllers'], function($routes) {
     $routes->get('register', 'AuthController::register', ['as' => 'register']);
     $routes->post('register', 'AuthController::attemptRegister');
 
+    // Activation
+    $routes->get('activate-account', 'AuthController::activateAccount', ['as' => 'activate-account']);
+
     // Forgot/Resets
     $routes->get('forgot', 'AuthController::forgotPassword', ['as' => 'forgot']);
     $routes->post('forgot', 'AuthController::attemptForgot');

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -7,6 +7,7 @@ use Myth\Auth\Models\LoginModel;
 use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
 use Myth\Auth\Authentication\Passwords\PasswordValidator;
+use Myth\Auth\Authentication\Activators\UserActivator;
 use CodeIgniter\Config\BaseService;
 
 class Services extends BaseService
@@ -88,5 +89,28 @@ class Services extends BaseService
         }
 
         return new PasswordValidator($config);
+    }
+
+    /**
+     * Returns an instance of the activator.
+     *
+     * @param null $config
+     * @param bool $getShared
+     *
+     * @return mixed|Activator
+     */
+    public static function activator($config = null, bool $getShared = true)
+    {
+        if ($getShared)
+        {
+            return self::getSharedInstance('activator', $config);
+        }
+
+        if (empty($config))
+        {
+            $config = config(Auth::class);
+        }
+
+        return new UserActivator($config);
     }
 }

--- a/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
@@ -82,6 +82,19 @@ class CreateAuthTables extends Migration
         $this->forge->createTable('auth_reset_attempts');
 
         /*
+         * Activation Attempts Table
+         */
+        $this->forge->addField([
+            'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'ip_address' => ['type' => 'varchar', 'constraint' => 255],
+            'user_agent' => ['type' => 'varchar', 'constraint' => 255],
+            'token'      => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
+            'created_at' => ['type' => 'datetime', 'null' => false],
+        ]);
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('auth_activation_attempts');
+
+        /*
          * Groups Table
          */
         $fields = [
@@ -170,6 +183,7 @@ class CreateAuthTables extends Migration
 		$this->forge->dropTable('auth_logins', true);
 		$this->forge->dropTable('auth_tokens', true);
 		$this->forge->dropTable('auth_reset_attempts', true);
+        $this->forge->dropTable('auth_activation_attempts', true);
 		$this->forge->dropTable('auth_groups', true);
 		$this->forge->dropTable('auth_permissions', true);
 		$this->forge->dropTable('auth_groups_permissions', true);

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -110,6 +110,41 @@ class User extends Entity
 		return $this;
 	}
 
+    /**
+     * Activate user.
+     *
+     * @return $this
+     */
+    public function activate()
+    {
+        $this->attributes['active'] = 1;
+        $this->attributes['activate_hash'] = null;
+
+        return $this;
+    }
+
+    /**
+     * Unactivate user.
+     *
+     * @return $this
+     */
+    public function unActivate()
+    {
+        $this->attributes['active'] = 0;
+
+        return $this;
+    }
+
+    /**
+     * Checks to see if a user is active.
+     *
+     * @return bool
+     */
+    public function isActivated(): bool
+    {
+        return isset($this->attributes['active']) && $this->attributes['active'] === true;
+    }
+
 	/**
 	 * Bans a user.
 	 *

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -128,7 +128,7 @@ class User extends Entity
      *
      * @return $this
      */
-    public function unActivate()
+    public function deactivate()
     {
         $this->attributes['active'] = 0;
 

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -22,6 +22,7 @@ return [
     'activationSubject'         => 'Activate your account',
     'activationSuccess'         => 'Please confirm your account by clicking the activation link in the email we have sent.',
     'notActivated'              => 'This user account is not yet activated.',
+    'errorSendingActivation'    => 'Failed to send activation message to: {0}',
 
     // Login
     'badAttempt'                => 'Unable to log you in. Please check your credentials.',

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -17,6 +17,12 @@ return [
     'registerSuccess'           => 'Welcome aboard! Please login with your new credentials.',
     'registerCLI'               => 'New user created: {0}, #{1}',
 
+    // Activation
+    'activationNoUser'          => 'Unable to locate a user with that activation code.',
+    'activationSubject'         => 'Activate your account',
+    'activationSuccess'         => 'Please confirm your account by clicking the activation link in the email we have sent.',
+    'notActivated'              => 'This user account is not yet activated.',
+
     // Login
     'badAttempt'                => 'Unable to log you in. Please check your credentials.',
     'loginSuccess'              => 'Welcome back!',
@@ -49,6 +55,9 @@ return [
 
     // Banned
     'userIsBanned'              => 'User has been banned. Contact the administrator',
+
+    // Too many requests
+    'tooManyRequests'           => 'Too many requests. Please wait {0, number} seconds.',
 
     // Login views
     'home'                      => 'Home',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -16,6 +16,12 @@ return [
     'registerDisabled'          => 'La creación de cuentas de usuario está deshabilitada.',
     'registerSuccess'           => '¡Bienvenido! Por favor ingrese sus credenciales.',
 
+    // Activation
+    'activationNoUser'          => 'Unable to locate a user with that activation code.', // translate
+    'activationSubject'         => 'Activate your account', // translate
+    'activationSuccess'         => 'Please confirm your account by clicking the activation link in the email we have sent.', // translate
+    'notActivated'              => 'This user account is not yet activated.', // translate
+
     // Login
     'badAttempt'                => 'No se pudo ingresar al sistema. Por favor, chequee sus credenciales.',
     'loginSuccess'              => '¡Bienvenido nuevamente!',
@@ -47,6 +53,9 @@ return [
 
     // Banned
     'userIsBanned'              => 'El usuario está deshabilitado. Contacte al administrador',
+
+    // Too many requests
+    'tooManyRequests'           => 'Too many requests. Please wait {0, number} seconds.', // translate
 
     // Login views
     'home'                      => 'Login',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -21,6 +21,7 @@ return [
     'activationSubject'         => 'Activate your account', // translate
     'activationSuccess'         => 'Please confirm your account by clicking the activation link in the email we have sent.', // translate
     'notActivated'              => 'This user account is not yet activated.', // translate
+    'errorSendingActivation'    => 'Failed to send activation message to: {0}', // translate
 
     // Login
     'badAttempt'                => 'No se pudo ingresar al sistema. Por favor, chequee sus credenciales.',

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -45,4 +45,21 @@ class UserModel extends Model
         ]);
     }
 
+    /**
+     * Logs an activation attempt for posterity sake.
+     *
+     * @param string|null $token
+     * @param string|null $ipAddress
+     * @param string|null $userAgent
+     */
+    public function logActivationAttempt(string $token = null, string $ipAddress = null, string $userAgent = null)
+    {
+        $this->db->table('auth_activation_attempts')->insert([
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
+            'token' => $token,
+            'created_at' => date('Y-m-d H:i:s')
+        ]);
+    }
+
 }

--- a/src/Views/emails/activation.php
+++ b/src/Views/emails/activation.php
@@ -1,0 +1,9 @@
+<p>This is activation email for your account on <?= base_url() ?>.</p>
+
+<p>To activate your account use this URL.</p>
+
+<p><a href="<?= base_url('activate-account') . '?token=' . $hash ?>">Activate account</a>.</p>
+
+<br>
+
+<p>If you did not registered on this website, you can safely ignore this email.</p>

--- a/tests/unit/LocalAuthenticateAttemptTest.php
+++ b/tests/unit/LocalAuthenticateAttemptTest.php
@@ -66,6 +66,7 @@ class LocalAuthenticateAttemptTest extends CIUnitTestCase
 
         $user = new User();
         $user->id = 5;
+        $user->active = true;
 
         $this->auth->shouldReceive('validate')->once()->with(\Mockery::subset($credentials), true)->andReturn($user);
         $this->auth->shouldReceive('login')->once()->andReturn(true);


### PR DESCRIPTION
This is a proposal for the account activation option.

In general - after registration user gets an email with an activation code. Useful when we want to be sure that the registered user is an actual email account owner. Or just to prevent simple bots a little.

I'm not sure about the `AuthController/activateAccount` code part - for now, I made it very simple.

I have a few questions and I'm looking for some discussion.

1. Should we log activation attempts or not?
2. If yes - should it be a separate table?
3. For now, I use only `Throttler` to prevent brute force attacks - should it be changed?
4. In my auth library from CI3 I use a combination of custom `token` + obfuscated `user_id` (via [jenssegers/optimus](https://github.com/jenssegers/optimus)) to activate user but here, I use only a `token`... it bothers me a bit, so I will be glad to hear your opinion about it. I’m not sure if you’re open to adding other packages.
5. Any other suggestions are welcomed.