### PR TITLE
NothingPersonalValidator class

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ perform the following setup:
 When first installed, Myth:Auth is setup to provide all of the basic authentication services 
 for you, including new user registration, login/logout, and forgotten password flows.
 
-Remember me functionality is turned off by default, though that can be turned on in Config/Auth.php
-by setting the `$allowRemembering` variable to be `true`.
+"Remember Me" functionality is turned off by default though it can be turned on 
+by setting the `$allowRemembering` variable to be `true` in Config/Auth.php.
 
 ### Routes
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -207,8 +207,9 @@ Valid range is between 4 - 31.
 	public $hashCost = 10;
 
 ### auth.passwordValidators
-This list holds the validators that should be ran when checking that a password is valid. This are ran one at a time, 
-in succession. You can easily add your own should you need to customize the validation rules.  
+This list holds the validators that will be run when checking that a password is valid. 
+These are run one at a time in succession. 
+You can easily add your own should you need to customize the validation rules.  
 
     public $passwordValidators = [
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
@@ -218,10 +219,10 @@ in succession. You can easily add your own should you need to customize the vali
 
 The default validators that come with Myth:Auth are:
 
-- CompositionValidator - per the latest NIST recommendations, simply checks password length.
-- DictionaryValidator - compares the password with over 600,000 leaked passwords and common words, as well as
-    variations on the user's personal info, like name and email.
-- PwnedValidator - compares the password with over half a billion of real-world passwords previously exposed in data breaches. 
-    It uses a request to third-party API. This validator is optional and disabled by default since not everyone may be 
-    comfortable with using it. The decision to use it or not is up to you - more information and technical details can 
-    be found [here](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity).
+- CompositionValidator - Per the latest NIST recommendations checks password length.
+- NothingPersonalValidator - Checks for variations on the user's personal info like name and email in the password.
+- DictionaryValidator - Compares the password with over 600,000 leaked passwords and common words in a dictionary included with this module. 
+- PwnedValidator - Looks for the password in a list of over 500 billion passwords exposed in data breaches.
+    Because PwnedValidator uses a request to third-party API not everyone may be comfortable with using it. Therefore, this validator is optional and disabled by default. The decision to use it or not is up to you. More information and technical details can be found [here](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity).
+    To use this validator simply remove the commented item in the $passwordValidators array.
+    PwnedValidator is a good replacement for the DictionaryValidator and you probably don't have to use both.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -220,9 +220,9 @@ You can easily add your own should you need to customize the validation rules.
 The default validators that come with Myth:Auth are:
 
 - CompositionValidator - Per the latest NIST recommendations checks password length.
-- NothingPersonalValidator - Checks for variations on the user's personal info like name and email in the password.
+- NothingPersonalValidator - Checks for variations on the user's personal info such as username and email in the password.
 - DictionaryValidator - Compares the password with over 600,000 leaked passwords and common words in a dictionary included with this module. 
-- PwnedValidator - Looks for the password in a list of over 500 billion passwords exposed in data breaches.
+- PwnedValidator - Looks for the password in a list of over 500 million passwords exposed in data breaches.
     Because PwnedValidator uses a request to third-party API not everyone may be comfortable with using it. Therefore, this validator is optional and disabled by default. The decision to use it or not is up to you. More information and technical details can be found [here](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/#cloudflareprivacyandkanonymity).
     To use this validator simply remove the commented item in the $passwordValidators array.
     PwnedValidator is a good replacement for the DictionaryValidator and you probably don't have to use both.

--- a/src/Authentication/Passwords/CompositionValidator.php
+++ b/src/Authentication/Passwords/CompositionValidator.php
@@ -69,6 +69,6 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
      */
     public function suggestion(): string
     {
-        return ;
+        return $this->suggestion;
     }
 }

--- a/src/Authentication/Passwords/CompositionValidator.php
+++ b/src/Authentication/Passwords/CompositionValidator.php
@@ -46,29 +46,6 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
             return false;
         }
         
-        // Don't allow personal information as the password
-        if ($user !== null)
-        {
-            $names = [
-                strtolower($user->name),
-                strtolower(str_replace(' ', '', $user->name)),
-                strtolower(str_replace(' ', '.', $user->name)),
-                strtolower(str_replace(' ', '-', $user->name)),
-            ];
-
-            $tPassword = strtolower($password);
-            if ($tPassword == strtolower($user->email)
-                || in_array($tPassword, $names, $user->name)
-                || $tPassword == strtolower($user->username)
-            )
-            {
-                $this->error = lang('Auth.errorPasswordPersonal');
-                $this->suggestion = lang('Auth.suggestPasswordPersonal');
-
-                return false;
-            }
-        }
-        
         return true;
     }
 

--- a/src/Authentication/Passwords/DictionaryValidator.php
+++ b/src/Authentication/Passwords/DictionaryValidator.php
@@ -22,51 +22,18 @@ class DictionaryValidator extends BaseValidator implements ValidatorInterface
     protected $suggestion;
 
     /**
-     * Checks the password and returns true/false
-     * if it passes muster. Must return either true/false.
-     * True means the password passes this test and
-     * the password will be passed to any remaining validators.
-     * False will immediately stop validation process
+     * Checks the password against the words in the file and returns false
+     * if a match is found. Returns true if no match is found.
+     * If true is returned the password will be passed to next validator.
+     * If false is returned the validation process will be immediately stopped.
      *
      * @param string $password
      * @param Entity $user
      *
-     * @return mixed
+     * @return boolean
      */
     public function check(string $password, Entity $user=null): bool
     {
-        $password = trim($password);
-
-        if (empty($password))
-        {
-            $this->error = lang('Auth.errorPasswordEmpty');
-
-            return false;
-        }
-
-        // Don't allow personal information as the password
-        if ($user !== null)
-        {
-            $names = [
-                strtolower($user->name),
-                strtolower(str_replace(' ', '', $user->name)),
-                strtolower(str_replace(' ', '.', $user->name)),
-                strtolower(str_replace(' ', '-', $user->name)),
-            ];
-
-            $tPassword = strtolower($password);
-            if ($tPassword == strtolower($user->email)
-                || in_array($tPassword, $names, $user->name)
-                || $tPassword == strtolower($user->username)
-            )
-            {
-                $this->error = lang('Auth.errorPasswordPersonal');
-                $this->suggestion = lang('Auth.suggestPasswordPersonal');
-
-                return false;
-            }
-        }
-
         // Loop over our file
         $fp = fopen(__DIR__ .'/_dictionary.txt', 'r');
         if ($fp)

--- a/src/Authentication/Passwords/NothingPersonalValidator.php
+++ b/src/Authentication/Passwords/NothingPersonalValidator.php
@@ -1,28 +1,30 @@
 <?php namespace Myth\Auth\Authentication\Passwords;
 
 use CodeIgniter\Entity;
-use Myth\Auth\Exceptions\AuthException;
 
 /**
- * Class CompositionValidator
+ * Class NothingPersonalValidator
  *
- * Checks the general makeup of the password.
- *
- * While older composition checks might have included different character
- * groups that you had to include, current NIST standards prefer to simply
- * set a minimum length and a long maximum (128+ chars).
- *
- * @see https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
- * 
+ * Checks password does not contain any personal information
  *
  * @package Myth\Auth\Authentication\Passwords\Validators
  */
-class CompositionValidator extends BaseValidator implements ValidatorInterface
+class NothingPersonalValidator extends BaseValidator implements ValidatorInterface
 {
     /**
-     * Returns true when the password passes this test. 
-     * The password will be passed to any remaining validators.
-     * False will immediately stop validation process
+     * @var string
+     */
+    protected $error;
+    /**
+     * @var string
+     */
+    protected $suggestion;
+
+    /**
+     * Returns true if $password contains no part of the username or the user's email. 
+     * Otherwise, it returns false. 
+     * If true is returned the password will be passed to next validator.
+     * If false is returned the validation process will be immediately stopped.
      *
      * @param string $password
      * @param Entity $user
@@ -31,21 +33,6 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
      */
     public function check(string $password, Entity $user=null): bool
     {
-        if (empty($this->config->minimumPasswordLength))
-        {
-            throw AuthException::forUnsetPasswordLength();
-        }
-
-        $passed = strlen($password) >= $this->config->minimumPasswordLength;
-
-        if(! $passed)
-        {
-            $this->error = lang('Auth.errorPasswordLength', [$this->config->minimumPasswordLength]);
-            $this->suggestion = lang('Auth.suggestPasswordLength');
-            
-            return false;
-        }
-        
         // Don't allow personal information as the password
         if ($user !== null)
         {
@@ -68,7 +55,7 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -79,7 +66,7 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
      */
     public function error(): string
     {
-        return $this->error;
+        return $this->error ?? '';
     }
 
     /**
@@ -92,6 +79,6 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
      */
     public function suggestion(): string
     {
-        return ;
+        return $this->suggestion ?? '';
     }
 }

--- a/src/Authentication/Passwords/NothingPersonalValidator.php
+++ b/src/Authentication/Passwords/NothingPersonalValidator.php
@@ -1,6 +1,7 @@
 <?php namespace Myth\Auth\Authentication\Passwords;
 
 use CodeIgniter\Entity;
+use Myth\Auth\Exceptions\AuthException;
 
 /**
  * Class NothingPersonalValidator
@@ -15,14 +16,15 @@ class NothingPersonalValidator extends BaseValidator implements ValidatorInterfa
      * @var string
      */
     protected $error;
+
     /**
      * @var string
      */
     protected $suggestion;
 
     /**
-     * Returns true if $password contains no part of the username or the user's email. 
-     * Otherwise, it returns false. 
+     * Returns true if $password contains no part of the username 
+     * or the user's email. Otherwise, it returns false. 
      * If true is returned the password will be passed to next validator.
      * If false is returned the validation process will be immediately stopped.
      *
@@ -31,32 +33,187 @@ class NothingPersonalValidator extends BaseValidator implements ValidatorInterfa
      *
      * @return boolean
      */
-    public function check(string $password, Entity $user=null): bool
+    public function check(string $password, Entity $user = null): bool
     {
-        // Don't allow personal information as the password
-        if ($user !== null)
+        $password = \strtolower($password);
+
+        if($valid = $this->isNotPersonal($password, $user) === true)
         {
-            $names = [
-                strtolower($user->name),
-                strtolower(str_replace(' ', '', $user->name)),
-                strtolower(str_replace(' ', '.', $user->name)),
-                strtolower(str_replace(' ', '-', $user->name)),
+            $valid = $this->isNotSimilar($password, $user);
+        }
+
+        return $valid;
+    }
+
+    /**
+     * isNotPersonal() 
+     * 
+     * Looks for personal information in a password. The personal info used
+     * comes from Myth\Auth\Entities\User properties username and email. 
+     * 
+     * It is possible to include other fields as information sources.
+     * For instance, a project might require adding `firstname` and `lastname` properties
+     * to an extended version of the User class. 
+     * The new fields can be included in personal information testing in by setting 
+     * the `$personalFields` property in Myth\Auth\Config\Auth, e.g.
+     * 
+     *      public $personalFields = ['firstname', 'lastname'];
+     * 
+     * isNotPersonal() returns true if no personal information can be found, or false
+     * if such info is found.
+     *  
+     * @param string $password
+     * @param Entity $user
+     * @return boolean
+     */
+    protected function isNotPersonal($password, $user)
+    {
+        $userName = \strtolower($user->username);
+        $email = \strtolower($user->email);
+        $valid = true;
+
+        // The most obvious transgressions
+        if($password === $userName ||
+            $password === $email ||
+            $password === strrev($userName))
+        {
+            $valid = false;
+        }
+
+        // Parse out as many pieces as possible from username, password and email.
+        // Use the pieces as needles and haystacks and look every which way for matches.
+        if($valid)
+        {
+            // Take username apart for use as search needles
+            $needles = $this->strip_explode($userName);
+
+            // extract local-part and domain parts from email as separate needles
+            [$localPart, $domain] = \explode('@', $email);
+            // might be john.doe@example.com and we want all the needles we can get
+            $emailParts = $this->strip_explode($localPart);
+            if( ! empty($domain))
+            {
+                $emailParts[] = $domain;
+            }
+            $needles = \array_merge($needles, $emailParts);
+
+            // Get any other "personal" fields defined in config
+            $personalFields = $this->config->personalFields;
+            if( ! empty($personalFields))
+            {
+                foreach($personalFields as $value)
+                {
+                    if( ! empty($user->$value))
+                    {
+                        $needles[] = \strtolower($user->$value);
+                    }
+                }
+            }
+
+            $trivial = [
+                'a', 'an', 'and', 'as', 'at', 'but', 'for',
+                'if', 'in', 'not', 'of', 'or', 'so', 'the', 'then'
             ];
 
-            $tPassword = strtolower($password);
-            if ($tPassword == strtolower($user->email)
-                || in_array($tPassword, $names, $user->name)
-                || $tPassword == strtolower($user->username)
-            )
-            {
-                $this->error = lang('Auth.errorPasswordPersonal');
-                $this->suggestion = lang('Auth.suggestPasswordPersonal');
+            // Make password into haystacks
+            $haystacks = $this->strip_explode($password);
 
+            foreach($haystacks as $haystack)
+            {
+                if(empty($haystack) || in_array($haystack, $trivial))
+                {
+                    continue;  //ignore trivial words
+                }
+
+                foreach($needles as $needle)
+                {
+                    if(empty($needle) || in_array($needle, $trivial))
+                    {
+                        continue;
+                    }
+
+                    // look both ways in case password is subset of needle
+                    if(strpos($haystack, $needle) !== false ||
+                        strpos($needle, $haystack) !== false)
+                    {
+                        $valid = false;
+                        break 2;
+                    }
+                }
+            }
+        }
+        if($valid)
+        {
+            return true;
+        }
+
+        $this->error = lang('Auth.errorPasswordPersonal');
+        $this->suggestion = lang('Auth.suggestPasswordPersonal');
+        return false;
+    }
+
+    /**
+     * notSimilar() uses $password and $userName to calculate a similarity value.
+     * Similarity values equal to, or greater than Myth\Auth\Config::maxSimilarity 
+     * are rejected for being too much alike and false is returned. 
+     * Otherwise, true is returned,
+     * 
+     * A $maxSimilarity value of 0 (zero) returns true without making a comparison.
+     * In other words, 0 (zero) turns off similarity testing.
+     * 
+     * @param string $password
+     * @param Entity $user
+     * @return boolean
+     */
+    protected function isNotSimilar($password, $user)
+    {
+        $maxSimilarity = (float) $this->config->maxSimilarity;
+        // sanity checking - working range 1-100, 0 is off
+        if($maxSimilarity < 1)
+        {
+            $maxSimilarity = 0;
+        }
+        elseif($maxSimilarity > 100)
+        {
+            $maxSimilarity = 100;
+        }
+
+        if( ! empty($maxSimilarity))
+        {
+            $userName = \strtolower($user->username);
+
+            similar_text($password, $userName, $similarity);
+            if($similarity >= $maxSimilarity)
+            {
+                $this->error = lang('Auth.errorPasswordTooSimilar');
+                $this->suggestion = lang('Auth.suggestPasswordTooSimilar');
                 return false;
             }
         }
-
         return true;
+    }
+
+    /**
+     * strip_explode($str)
+     * 
+     * Replaces all non-word characters and underscores in $str with a space. 
+     * Then it explodes that result using the space for a delimiter.
+     * 
+     * @param string $str
+     * @return array
+     */
+    protected function strip_explode($str)
+    {
+        $stripped = \preg_replace('/[\W_]+/', ' ', $str);
+        $parts = \explode(' ', \trim($stripped));
+
+        // If it's not already there put the untouched input at the top of the array
+        if( ! in_array($str, $parts))
+        {
+            array_unshift($parts, $str);
+        }
+
+        return $parts;
     }
 
     /**
@@ -81,4 +238,5 @@ class NothingPersonalValidator extends BaseValidator implements ValidatorInterfa
     {
         return $this->suggestion ?? '';
     }
+
 }

--- a/src/Authentication/Passwords/PasswordValidator.php
+++ b/src/Authentication/Passwords/PasswordValidator.php
@@ -2,6 +2,7 @@
 
 use Myth\Auth\Config\Auth;
 use Myth\Auth\Entities\User;
+use Myth\Auth\Exceptions\AuthException;
 
 class PasswordValidator
 {
@@ -28,25 +29,30 @@ class PasswordValidator
      *
      * @return bool
      */
-    public function check(string $password, User $user=null): bool
+    public function check(string $password, User $user = null): bool
     {
+        if(is_null($user))
+        {
+            throw AuthException::forNoEntityProvided();
+        }
+
         $password = trim($password);
 
-        if (empty($password))
+        if(empty($password))
         {
             $this->error = lang('Auth.errorPasswordEmpty');
 
             return false;
         }
-        
+
         $valid = false;
 
-        foreach ($this->config->passwordValidators as $className)
+        foreach($this->config->passwordValidators as $className)
         {
             $class = new $className();
             $class->setConfig($this->config);
 
-            if ($class->check($password, $user) === false)
+            if($class->check($password, $user) === false)
             {
                 $this->error = $class->error();
                 $this->suggestion = $class->suggestion();
@@ -82,6 +88,5 @@ class PasswordValidator
     {
         return $this->suggestion;
     }
-
 
 }

--- a/src/Authentication/Passwords/PasswordValidator.php
+++ b/src/Authentication/Passwords/PasswordValidator.php
@@ -30,6 +30,15 @@ class PasswordValidator
      */
     public function check(string $password, User $user=null): bool
     {
+        $password = trim($password);
+
+        if (empty($password))
+        {
+            $this->error = lang('Auth.errorPasswordEmpty');
+
+            return false;
+        }
+        
         $valid = false;
 
         foreach ($this->config->passwordValidators as $className)

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Myth\Auth\Authentication\Passwords;
 
@@ -37,16 +37,10 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
     protected $suggestion;
 
     /**
-<<<<<<< HEAD
      * Checks the password against the online database and 
      * returns false if a match is found. Returns true if no match is found.
      * If true is returned the password will be passed to next validator.
      * If false is returned the validation process will be immediately stopped.
-=======
-     * Checks the password and returns true if it passes this test, or false if not.
-     * True means the password will be passed to any remaining validators.
-     * False will immediately stop validation process
->>>>>>> develop
      *
      * @param string $password
      * @param Entity $user
@@ -55,39 +49,6 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
      */
     public function check(string $password, Entity $user = null): bool
     {
-<<<<<<< HEAD
-        $password   = strtoupper(sha1($password));
-        $rangeHash  = substr($password, 0, 5);
-        $searchHash = substr($password, 5);
-
-        $client = Services::curlrequest([
-            'base_uri' => 'https://api.pwnedpasswords.com/',
-        ]);
-
-        $response = $client->get('range/' . $rangeHash, ['headers' => ['Accept' => 'text/plain']]);
-        $range = $response->getBody();
-        $startPos = strpos($range, $searchHash);
-        if($startPos === false)
-        {
-            return true;
-        }
-
-        $startPos += 36; // right after the delimiter (:)
-        $endPos = strpos($range, "\r\n", $startPos);
-        if($endPos !== false)
-            {
-            $hits = (int) substr($range, $startPos, $endPos - $startPos);
-            }
-=======
-        $password = trim($password);
-
-        if(empty($password))
-        {
-            $this->error = lang('Auth.errorPasswordEmpty');
-
-            return false;
-        }
-
         $hashedPword = strtoupper(sha1($password));
         $rangeHash = substr($hashedPword, 0, 5);
         $searchHash = substr($hashedPword, 5);
@@ -122,7 +83,6 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
         {
             $hits = (int) substr($range, $startPos, $endPos - $startPos);
         }
->>>>>>> develop
         else
         {
             // match is the last item in the range which does not end with "\r\n"
@@ -132,11 +92,7 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
         $wording = $hits > 1 ? "databases" : "a database";
         $this->error = lang('Auth.errorPasswordPwned', [$password, $hits, $wording]);
         $this->suggestion = lang('Auth.suggestPasswordPwned', [$password]);
-<<<<<<< HEAD
         
-=======
-
->>>>>>> develop
         return false;
     }
 

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -7,11 +7,11 @@ use Myth\Auth\Exceptions\AuthException;
 /**
  * Class PwnedValidator
  *
- * Checks if the password has been compromised.
+ * Checks if the password has been compromised by checking against 
+ * an online database of over 555 million stolen passwords.
+ * @see https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/
  *
  * NIST recommend to check passwords against those obtained from previous data breaches.
- *
- * @see https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/
  * @see https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
  *
  * @package Myth\Auth\Authentication\Passwords\Validators
@@ -33,11 +33,10 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
     protected $suggestion;
 
     /**
-     * Checks the password and returns true/false
-     * if it passes muster. Must return either true/false.
-     * True means the password passes this test and
-     * the password will be passed to any remaining validators.
-     * False will immediately stop validation process
+     * Checks the password against the online database and 
+     * returns false if a match is found. Returns true if no match is found.
+     * If true is returned the password will be passed to next validator.
+     * If false is returned the validation process will be immediately stopped.
      *
      * @param string $password
      * @param Entity $user
@@ -46,15 +45,6 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
      */
     public function check(string $password, Entity $user = null): bool
     {
-        $password = trim($password);
-
-        if (empty($password))
-        {
-            $this->error = lang('Auth.errorPasswordEmpty');
-
-            return false;
-        }
-
         $password   = strtoupper(sha1($password));
         $rangeHash  = substr($password, 0, 5);
         $searchHash = substr($password, 5);
@@ -64,21 +54,30 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
         ]);
 
         $response = $client->get('range/' . $rangeHash, ['headers' => ['Accept' => 'text/plain']]);
-
-        foreach (explode("\r\n", $response->getBody()) as $line)
+        $range = $response->getBody();
+        $startPos = strpos($range, $searchHash);
+        if($startPos === false)
         {
-            list($hash, $hits) = explode(':', $line);
-
-            if ($hash === $searchHash)
-            {
-                $this->error = lang('Auth.errorPasswordPwned', [(int) $hits]);
-                $this->suggestion = lang('Auth.suggestPasswordPwned');
-
-                return false;
-            }
+            return true;
         }
 
-        return true;
+        $startPos += 36; // right after the delimiter (:)
+        $endPos = strpos($range, "\r\n", $startPos);
+        if($endPos !== false)
+            {
+            $hits = (int) substr($range, $startPos, $endPos - $startPos);
+            }
+        else
+        {
+            // match is the last item in the range which does not end with "\r\n"
+            $hits = (int) substr($range, $startPos);
+        }
+
+        $wording = $hits > 1 ? "databases" : "a database";
+        $this->error = lang('Auth.errorPasswordPwned', [$password, $hits, $wording]);
+        $this->suggestion = lang('Auth.suggestPasswordPwned', [$password]);
+        
+        return false;
     }
 
     /**

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -18,13 +18,13 @@ class Auth extends BaseConfig
     //--------------------------------------------------------------------
 
     public $views = [
-        'login'     => 'Myth\Auth\Views\login',
-        'register'  => 'Myth\Auth\Views\register',
-        'forgot'    => 'Myth\Auth\Views\forgot',
-        'reset'     => 'Myth\Auth\Views\reset',
+        'login' => 'Myth\Auth\Views\login',
+        'register' => 'Myth\Auth\Views\register',
+        'forgot' => 'Myth\Auth\Views\forgot',
+        'reset' => 'Myth\Auth\Views\reset',
         'emailForgot' => 'Myth\Auth\Views\emails\forgot',
     ];
-    
+
     //--------------------------------------------------------------------
     // Layout for the views to extend
     //--------------------------------------------------------------------
@@ -34,11 +34,59 @@ class Auth extends BaseConfig
     //--------------------------------------------------------------------
     // Authentication
     //--------------------------------------------------------------------
-
     // Fields that are available to be used as credentials for login.
     public $validFields = [
         'email', 'username'
     ];
+
+    //--------------------------------------------------------------------
+    // Additional Fields for "Nothing Personal"
+    //--------------------------------------------------------------------
+    // The NothingPersonalValidator prevents personal information from 
+    // being used in passwords. The email and username fields are always 
+    // considered by the validator. Do not enter those field names here.
+    // 
+    // An extend User Entity might include other personal info such as 
+    // first and/or last names. $personalFields is where you can add 
+    // fields to be considered as "personal" by the NothingPersonalValidator. 
+    // For example: 
+    //     $personalFields = ['firstname', 'lastname'];
+
+    public $personalFields = [];
+
+    //--------------------------------------------------------------------
+    // Password / Username Similarity
+    //--------------------------------------------------------------------
+    //  Among other things, the NothingPersonalValidator checks the 
+    //  amount of sameness between the password and username. 
+    //  Passwords that are too much like the username are invalid. 
+    //  
+    //  The value set for $maxSimilarity represents the maximum percentage
+    //  of similarity at which the password will be accepted. In other words, any
+    //  calculated similarity equal to, or greater than $maxSimilarity
+    //  is rejected.
+    //   
+    //  The accepted range is 0-100, with 0 (zero) meaning don't check similarity.
+    //  Using values at either extreme of the *working range* (1-100) is 
+    //  not advised. The low end is too restrictive and the high end is too permissive.  
+    //  The suggested value for $maxSimilarity is 50. 
+    //  
+    //  You may be thinking that a value of 100 should have the effect of accepting
+    //  everything like a value of 0 does. That's logical and probably true, 
+    //  but is unproven and untested. Besides, 0 skips the work involved 
+    //  making the calculation unlike when using 100.
+    //  
+    //  The (admittedly limited) testing that's been done suggests a useful working range 
+    //  of 50 to 60. You can set it lower than 50, but site users will probably start
+    //  to complain about the large number of proposed passwords getting rejected. 
+    //  At around 60 or more it starts to see pairs like 'captain joe' and 'joe*captain' as 
+    //  perfectly acceptable which clearly they are not.
+    //
+ 
+    //  To disable similarity checking set the value to 0. 
+    //      public $maxSimilarity = 0; 
+    //      
+    public $maxSimilarity = 50;
 
     //--------------------------------------------------------------------
     // Allow User Registration
@@ -75,23 +123,24 @@ class Auth extends BaseConfig
     //
     public $silent = false;
 
-    /*--------------------------------------------------------------------
-	 * Encryption Algorithm to use
-	 *--------------------------------------------------------------------
-	 * Valid values are
-	 * - PASSWORD_DEFAULT (default)
-	 * - PASSWORD_BCRYPT
-	 * - PASSWORD_ARGON2I  - As of PHP 7.2 only if compiled with support for it
-	 * - PASSWORD_ARGON2ID - As of PHP 7.3 only if compiled with support for it
-	 *
-	 * If you choose to use any ARGON algorithm, then you might want to
-	 * uncomment the "ARGON2i/D Algorithm" options to suit your needs
+    /* --------------------------------------------------------------------
+     * Encryption Algorithm to use
+     * --------------------------------------------------------------------
+     * Valid values are
+     * - PASSWORD_DEFAULT (default)
+     * - PASSWORD_BCRYPT
+     * - PASSWORD_ARGON2I  - As of PHP 7.2 only if compiled with support for it
+     * - PASSWORD_ARGON2ID - As of PHP 7.3 only if compiled with support for it
+     *
+     * If you choose to use any ARGON algorithm, then you might want to
+     * uncomment the "ARGON2i/D Algorithm" options to suit your needs
      */
-	public $hashAlgorithm = PASSWORD_DEFAULT;
 
-	/*--------------------------------------------------------------------
-	 * ARGON2i/D Algorithm options
-	 *--------------------------------------------------------------------
+    public $hashAlgorithm = PASSWORD_DEFAULT;
+
+    /* --------------------------------------------------------------------
+     * ARGON2i/D Algorithm options
+     * --------------------------------------------------------------------
      * The ARGON2I method of encryption allows you to define the "memory_cost",
      * the "time_cost" and the number of "threads", whenever a password hash is
      * created.
@@ -101,9 +150,11 @@ class Auth extends BaseConfig
      * cost. This makes the hashing process takes longer.
      */
 
-	public $hashMemoryCost = 2048; 	//PASSWORD_ARGON2_DEFAULT_MEMORY_COST;
-	public $hashTimeCost = 4; 		//PASSWORD_ARGON2_DEFAULT_TIME_COST;
-	public $hashThreads = 4; 		//PASSWORD_ARGON2_DEFAULT_THREADS;
+    public $hashMemoryCost = 2048;  //PASSWORD_ARGON2_DEFAULT_MEMORY_COST;
+
+    public $hashTimeCost = 4;   //PASSWORD_ARGON2_DEFAULT_TIME_COST;
+
+    public $hashThreads = 4;   //PASSWORD_ARGON2_DEFAULT_THREADS;
 
     //--------------------------------------------------------------------
     // Password Hashing Cost
@@ -148,4 +199,5 @@ class Auth extends BaseConfig
     // in seconds.
     //
     public $resetTime = 3600;
+
 }

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -130,6 +130,7 @@ class Auth extends BaseConfig
     //
     public $passwordValidators = [
         'Myth\Auth\Authentication\Passwords\CompositionValidator',
+        'Myth\Auth\Authentication\Passwords\NothingPersonalValidator',
         'Myth\Auth\Authentication\Passwords\DictionaryValidator',
         //'Myth\Auth\Authentication\Passwords\PwnedValidator',
     ];

--- a/src/Exceptions/AuthException.php
+++ b/src/Exceptions/AuthException.php
@@ -45,7 +45,7 @@ class AuthException extends \DomainException implements ExceptionInterface
     }
 
     /**
-     * When the cURL request in PwnedValidator (to Have I Been Pwned) 
+     * When the cURL request (to Have I Been Pwned) in PwnedValidator 
      * throws a HTTPException it is re-thrown as this one
      *
      * @return AuthException
@@ -54,5 +54,15 @@ class AuthException extends \DomainException implements ExceptionInterface
     {
         return new self($e->getMessage(), $e->getCode(), $e);
     }
-    
+
+    /**
+     * When no User Entity is passed into PasswordValidator::check()
+     *
+     * @return AuthException
+     */
+    public static function forNoEntityProvided()
+    {
+        return new self(lang('Auth.noUserEntity'), 500);
+    }
+
 }

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -4,11 +4,11 @@ return [
     // Exceptions
     'invalidModel'              => 'The {0} model must be loaded prior to use.',
     'userNotFound'              => 'Unable to locate a user with ID = {0, number}.',
+    'noUserEntity'              => 'User Entity must be provided for password validation.',
     'tooManyCredentials'        => 'You may only validate against 1 credential other than a password.',
     'invalidFields'             => 'The "{0}" field cannot be used to validate credentials.',
     'unsetPasswordLength'       => 'You must set the `minimumPasswordLength` setting in the Auth config file.',
     'unknownError'              => 'Sorry, we encountered an issue sending the email to you. Please try again later.',
-
     'notLoggedIn'               => 'You must be logged in to access that page.',
     'notEnoughPrivilege'        => 'You do not have sufficient permissions to access that page.',
 
@@ -34,6 +34,8 @@ return [
     'suggestPasswordCommon'     => 'The password was checked against over 65k commonly used passwords or passwords that have been leaked through hacks.',
     'errorPasswordPersonal'     => 'Passwords cannot contain re-hashed personal information.',
     'suggestPasswordPersonal'   => 'Variations on your email address or username should not be used for passwords.',
+    'errorPasswordTooSimilar'    => 'Password is too similar to the username.',
+    'suggestPasswordTooSimilar'  => 'Do not use parts of your username in your password.',
     'errorPasswordPwned'        => 'The password {0} has been exposed due to a data breach and has been seen {1, number} times in {2} of compromised passwords.',
     'suggestPasswordPwned'      => '{0} should never be used as a password. If you are using it anywhere change it immediately.',
     'errorPasswordEmpty'        => 'A Password is required.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -4,17 +4,18 @@ return [
     // Exceptions
     'invalidModel'              => 'Se debe cargar el modelo {0} antes de usarlo.',
     'userNotFound'              => 'No se puede localizar al usuario con ID = {0, number}.',
+    'noUserEntity'              => 'User Entity must be provided for password validation.', //todo: translate
     'tooManyCredentials'        => 'Sólo se puede valir contra 1 credencial además de la contraseña.',
     'invalidFields'             => 'El campo "{0}" no puede utilizarse para validar credenciales.',
     'unsetPasswordLength'       => 'Se debe setear la variable `minimumPasswordLength` en la configuración.',
     'unknownError'              => 'Perdón, ocurrió un problema queriendo enviar el correo. Por favor intentá mas tarde.',
-
     'notLoggedIn'               => 'Se debe ingresar al sistema antes de poder acceder a esa página.',
     'notEnoughPrivilege'        => 'No tenés los permisos necesarios para poder acceder a esta página.',
 
     // Registration
     'registerDisabled'          => 'La creación de cuentas de usuario está deshabilitada.',
     'registerSuccess'           => '¡Bienvenido! Por favor ingrese sus credenciales.',
+    'registerCLI'               => 'New user created: {0}, #{1}', //todo: translate
 
     // Login
     'badAttempt'                => 'No se pudo ingresar al sistema. Por favor, chequee sus credenciales.',
@@ -33,11 +34,14 @@ return [
     'suggestPasswordCommon'     => 'La contraseña fue contrastada contra 65.000 de uso habitual y las que fueron hackeadas.',
     'errorPasswordPersonal'     => 'Las contraseñas no pueden contener información personal.',
     'suggestPasswordPersonal'   => 'Variaciones de su e-mail o usuario no deben usarse como contraseñas.',
-    'errorPasswordPwned'        => 'This password has been seen {0, number} times before. It was found in a database of compromised passwords.', // translate
-    'suggestPasswordPwned'      => 'This password has previously appeared in a data breach and should never be used. If you\'ve used it anywhere before, change it immediately.', // translate
+    'errorPasswordTooSimilar'    => 'Password is too similar to the username.',  //todo: translate
+    'suggestPasswordTooSimilar'  => 'Do not use parts of your username in your password.',  //todo: translate
+    'errorPasswordPwned'        => 'The password {0} has been exposed due to a data breach and has been seen {1, number} times in {2} of compromised passwords.',//todo: translate
+    'suggestPasswordPwned'      => '{0} should never be used as a password. If you are using it anywhere change it immediately.', //todo: translate
     'errorPasswordEmpty'        => 'Se requiere una contraseña.',
     'passwordChangeSuccess'     => 'Contraseña cambiada',
     'userDoesNotExist'          => 'No se cambió la contraseña. El usuario no existe',
+    'resetTokenExpired'         => 'Sorry. Your reset token has expired.', //todo: translate
 
     // Groups
     'groupNotFound'             => 'No se puede localizar al grupo: {0}.',

--- a/tests/unit/DictionaryValidatorTest.php
+++ b/tests/unit/DictionaryValidatorTest.php
@@ -41,25 +41,4 @@ class DictionaryValidatorTest extends CIUnitTestCase
         $this->assertTrue($this->validator->check($password));
     }
 
-    public function testCheckFalseOnEmailMatch()
-    {
-        $user = new \Myth\Auth\Entities\User([
-            'email' => 'JoeSmith@example.com'
-        ]);
-
-        $password = 'joesmith@example.com';
-
-        $this->assertFalse($this->validator->check($password, $user));
-    }
-
-    public function testCheckFalseOnUsernameMatch()
-    {
-        $user = new \Myth\Auth\Entities\User([
-            'username' => 'CaptainJoe'
-        ]);
-
-        $password = 'captainjoe';
-
-        $this->assertFalse($this->validator->check($password, $user));
-    }
 }

--- a/tests/unit/DictionaryValidatorTest.php
+++ b/tests/unit/DictionaryValidatorTest.php
@@ -20,13 +20,6 @@ class DictionaryValidatorTest extends CIUnitTestCase
         $this->validator->setConfig($config);
     }
 
-    public function testCheckFalseOnEmptyPassword()
-    {
-        $password = '';
-
-        $this->assertFalse($this->validator->check($password));
-    }
-
     public function testCheckFalseOnFoundPassword()
     {
         $password = '!!!gerard!!!';

--- a/tests/unit/NothingPersonalValidatorTest.php
+++ b/tests/unit/NothingPersonalValidatorTest.php
@@ -1,0 +1,201 @@
+<?php
+use CodeIgniter\Test\CIUnitTestCase;
+use Myth\Auth\Authentication\Passwords\NothingPersonalValidator;
+
+class NothingPersonalValidatorTest extends CIUnitTestCase
+{
+    /**
+     * @var CompositionValidator
+     */
+    protected $validator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $config = new \Myth\Auth\Config\Auth();
+        //
+//        $config->personalFields = [];//['firstname', 'lastname'];
+
+        $this->validator = new NothingPersonalValidator();
+        $this->validator->setConfig($config);
+    }
+
+    public function testFalseOnPasswordIsEmail()
+    {
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'email' => 'JoeSmith@example.com',
+            'username' => 'Joe Smith'
+            ]
+        );
+
+        $password = 'joesmith@example.com';
+
+        $this->assertFalse($this->validator->check($password, $user));
+    }
+
+    public function testFalseOnPasswordIsUsernameBackwards()
+    {
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'email' => 'JoeSmith@example.com',
+            'username' => 'Joe Smith'
+            ]
+        );
+
+        $password = 'Htims Eoj';
+
+        $this->assertFalse($this->validator->check($password, $user));
+    }
+
+    public function testFalseOnPasswordAndUsernameTheSame()
+    {
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'email' => 'vampire@example.com',
+            'username' => 'Vlad the Impaler'
+            ]
+        );
+
+        $password = 'Vlad the Impaler';
+
+        $this->assertFalse($this->validator->check($password, $user));
+    }
+
+    public function testTrueWhenPasswordHasNothingPersonal()
+    {
+        $config = new \Myth\Auth\Config\Auth();
+        $config->maxSimilarity = 50;
+        $config->personalFields = ['firstname', 'lastname'];
+        $this->validator->setConfig($config);
+
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'email' => 'jsmith@example.com',
+            'username' => 'JoeS',
+            'firstname' => 'Joseph',
+            'lastname' => 'Smith',
+            ]
+        );
+
+        $password = 'opensesame';
+
+        $this->assertTrue($this->validator->check($password, $user));
+    }
+
+    /**
+     * The dataProvider is a list of passwords to be tested. 
+     * Some of them clearly contain elements of the username. 
+     * Others are scrambled usernames that may not clearly be troublesome, 
+     * but arguably should considered troublesome.
+     * 
+     * All the passwords are accepted by isNotPersonal() but are
+     * rejected by isNotSimilar().
+     * 
+     *  $config->maxSimilarity = 50; is the highest setting where all tests pass.
+     * 
+     * @dataProvider passwordProvider
+     */
+    public function testIsNotPersonalFalsePositivesCaughtByIsNotSimilar($password)
+    {
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'username' => 'CaptainJoe',
+            'email' => 'JosephSmith@example.com'
+            ]
+        );
+
+        $config = new \Myth\Auth\Config\Auth();
+        $config->maxSimilarity = 50;
+        $this->validator->setConfig($config);
+
+        $isNotPersonal = $this->getPrivateMethodInvoker($this->validator, 'isNotPersonal',
+            [$password, $user]);
+
+        $isNotSimilar = $this->getPrivateMethodInvoker($this->validator, 'isNotSimilar',
+            [$password, $user]);
+
+        $this->assertNotSame($isNotPersonal, $isNotSimilar);
+    }
+
+    public function passwordProvider()
+    {
+        return [
+            ['JoeTheCaptain'],
+            ['JoeCaptain'],
+            ['CaptainJ'],
+            ['captainjoseph'],
+            ['captjoeain'],
+            ['tajipcanoe'],
+            ['jcaptoeain'],
+            ['jtaincapoe'],
+        ];
+    }
+
+    /**
+     * @dataProvider firstLastNameProvider
+     */
+    public function testConfigPersonalFieldsValues($firstName, $lastName, $expected)
+    {
+        $config = new \Myth\Auth\Config\Auth();
+        $config->maxSimilarity = 66;
+        $config->personalFields = ['firstname', 'lastname'];
+        $this->validator->setConfig($config);
+
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'username' => 'Vlad the Impaler',
+            'email' => 'vampire@example.com',
+            'firstname' => $firstName,
+            'lastname' => $lastName,
+            ]
+        );
+
+        $password = 'Count Dracula';
+
+        $this->assertSame($expected, $this->validator->check($password, $user));
+    }
+
+    public function firstLastNameProvider()
+    {
+        return [
+            ['Count', '', false],
+            ['', 'Dracula', false],
+            ['Vlad', 'the Impaler', true],
+        ];
+    }
+
+    /**
+     * @dataProvider maxSimilarityProvider
+     * 
+     * The calculated similarity of 'captnjoe' and 'CaptainJoe' is 88.89.
+     * With $config->maxSimilarity = 66; the password should be rejected,
+     * but using $config->maxSimilarity = 0; will turn off the calculation 
+     * and accept the password. 
+     */
+    public function testMaxSimilarityZeroTurnsOffSimilarityCalculation($maxSimilarity,
+                                                                       $expected)
+    {
+        $config = new \Myth\Auth\Config\Auth();
+        $config->maxSimilarity = $maxSimilarity;
+        $this->validator->setConfig($config);
+
+        $user = new \Myth\Auth\Entities\User(
+            [
+            'username' => 'CaptainJoe',
+            'email' => 'joseph@example.com',
+            ]
+        );
+
+        $password = 'captnjoe';
+
+        $this->assertSame($expected, $this->validator->check($password, $user));
+    }
+
+    public function maxSimilarityProvider()
+    {
+        return[[66, false], [0, true]];
+    }
+
+}

--- a/tests/unit/PwnedValidatorTest.php
+++ b/tests/unit/PwnedValidatorTest.php
@@ -25,13 +25,6 @@ class PwnedValidatorTest extends CIUnitTestCase
         $this->validator = new PwnedValidator();
     }
 
-    public function testCheckFalseOnEmptyPassword()
-    {
-        $password = '';
-
-        $this->assertFalse($this->validator->check($password));
-    }
-
     public function testCheckFalseOnPwnedPassword()
     {
         $body = implode("\r\n",


### PR DESCRIPTION
Moves finding personal info in a password out of CompositionValidator and into its own class.
Includes a "similarity" test using password and username.
Adds the ability to designate (via config) additional fields to be used as personal info sources.

#124 
