### PR TITLE
Change isActive to be type agnostic

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -142,7 +142,7 @@ class User extends Entity
      */
     public function isActivated(): bool
     {
-        return isset($this->attributes['active']) && $this->attributes['active'] === true;
+        return isset($this->attributes['active']) && $this->attributes['active'] == true;
     }
 
 	/**


### PR DESCRIPTION
**Entities/User.php** currently checks if a user is active by checking if `$this->attributes['active'] === true`, but since internal functions don't use casts this attribute will rarely (never?) be a boolean. This PR changes the comparison to `==` which will allow for common database boolean type returns (e.g. `1`).