### PR TITLE
Replace invalidUser with badAttempt

### DIFF
--- a/src/Authentication/LocalAuthenticator.php
+++ b/src/Authentication/LocalAuthenticator.php
@@ -144,7 +144,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
 
         if (! $user)
         {
-            $this->error = lang('Auth.invalidUser');
+            $this->error = lang('Auth.badAttempt');
             return false;
         }
 

--- a/tests/authentication/LocalAuthTest.php
+++ b/tests/authentication/LocalAuthTest.php
@@ -61,7 +61,7 @@ class LocalAuthTest extends AuthTestCase
     public function testValidateUserNotFound()
     {
         $this->assertFalse($this->auth->validate(['email' => 'fred@example.com', 'password' => 'bar']));
-        $this->assertEquals(lang('Auth.invalidUser'), $this->auth->error());
+        $this->assertEquals(lang('Auth.badAttempt'), $this->auth->error());
     }
 
     public function testValidateBadPassword()

--- a/tests/unit/LocalAuthenticateValidateTest.php
+++ b/tests/unit/LocalAuthenticateValidateTest.php
@@ -82,7 +82,7 @@ class LocalAuthenticateValidateTest extends CIUnitTestCase
         ]);
 
         $this->assertFalse($result);
-        $this->assertEquals('Auth.invalidUser', $this->auth->error());
+        $this->assertEquals('Auth.badAttempt', $this->auth->error());
     }
 
     public function testFailsPasswordValidation()


### PR DESCRIPTION
There are a few references to `lang('Auth.invalidUser')`, which doesn't exist. Rather than adding that string this PR replaces the references to the existing language string `badAttempt`, as it is generally better to be opaque about whether the user account exists or not on login attempts.