### PR TITLE
Correct countAll to countAllResults

### DIFF
--- a/src/Authorization/PermissionModel.php
+++ b/src/Authorization/PermissionModel.php
@@ -32,7 +32,7 @@ class PermissionModel extends Model
         $count = $this->db->table('auth_users_permissions')
             ->where('permission_id', $permissionId)
             ->where('user_id', $userId)
-            ->countAll();
+            ->countAllResults();
 
         if ($count > 0)
         {
@@ -44,7 +44,7 @@ class PermissionModel extends Model
             ->join('auth_groups_users', 'auth_groups_users.user_id = '. $this->db->escape($userId), 'inner')
             ->where('auth_groups_permissions.permission_id', $permissionId)
             ->where('auth_groups_users.user_id', $userId)
-            ->countAll();
+            ->countAllResults();
 
         return $count > 0;
     }


### PR DESCRIPTION
`countAll()` now returns all result regardless of `where()`, etc, filters causing **PermissionModel** to approve any request as long as there are permissions. How that for generous!

This PR adjusts **PermissionModel** to use `countAllResults()` instead, which will respect the `WHERE` clause.