### PR TITLE
Preload helpers on all filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ that includes the following helper functions to ease access to basic features. B
 load the helper before using these functions: `helper('auth');`
 
 **Hint**: Add `'auth'` to any controller's `$helper` property to have it loaded automatically,
-or the same in **app/Controllers/BaseController.php** to have it globally available.
+or the same in **app/Controllers/BaseController.php** to have it globally available. the
+auth filters all pre-load the helper so it is available on any filtered routes.
 
 **logged_in()**
 

--- a/src/Filters/LoginFilter.php
+++ b/src/Filters/LoginFilter.php
@@ -23,16 +23,21 @@ class LoginFilter implements FilterInterface
 	 */
 	public function before(RequestInterface $request)
 	{
-        $current = (string)current_url(true)
-            ->setHost('')
-            ->setScheme('')
-            ->stripQuery('token');
+		if (! function_exists('logged_in'))
+		{
+			helper('auth');
+		}
 
-        // Make sure this isn't already a login route
-        if (in_array((string)$current, [route_to('login'), route_to('forgot'), route_to('reset-password')]))
-        {
-            return;
-        }
+		$current = (string)current_url(true)
+			->setHost('')
+			->setScheme('')
+			->stripQuery('token');
+
+		// Make sure this isn't already a login route
+		if (in_array((string)$current, [route_to('login'), route_to('forgot'), route_to('reset-password')]))
+		{
+			return;
+		}
 
 		// if no user is logged in then send to the login form
 		$authenticate = Services::authentication();

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -7,77 +7,82 @@ use CodeIgniter\Filters\FilterInterface;
 
 class PermissionFilter implements FilterInterface
 {
-    /**
-     * Do whatever processing this filter needs to do.
-     * By default it should not return anything during
-     * normal execution. However, when an abnormal state
-     * is found, it should return an instance of
-     * CodeIgniter\HTTP\Response. If it does, script
-     * execution will end and that Response will be
-     * sent back to the client, allowing for error pages,
-     * redirects, etc.
-     *
-     * @param \CodeIgniter\HTTP\RequestInterface $request
-     * @param array|null                         $params
-     *
-     * @return mixed
-     */
-    public function before(RequestInterface $request, $params = null)
-    {
+	/**
+	 * Do whatever processing this filter needs to do.
+	 * By default it should not return anything during
+	 * normal execution. However, when an abnormal state
+	 * is found, it should return an instance of
+	 * CodeIgniter\HTTP\Response. If it does, script
+	 * execution will end and that Response will be
+	 * sent back to the client, allowing for error pages,
+	 * redirects, etc.
+	 *
+	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param array|null                         $params
+	 *
+	 * @return mixed
+	 */
+	public function before(RequestInterface $request, $params = null)
+	{
+		if (! function_exists('logged_in'))
+		{
+			helper('auth');
+		}
+
 		if (empty($params))
 		{
 			return;
 		}
-		
-        $authenticate = Services::authentication();
-		
-		// if no user is logged in then send to the login form
-        if (! $authenticate->check())
-        {
-			session()->set('redirect_url', current_url());
-            return redirect('login');
-        }
 
-        $authorize = Services::authorization();
+		$authenticate = Services::authentication();
+
+		// if no user is logged in then send to the login form
+		if (! $authenticate->check())
+		{
+			session()->set('redirect_url', current_url());
+			return redirect('login');
+		}
+
+		$authorize = Services::authorization();
 		$result = true;
-		
+
 		// Check each requested permission
 		foreach ($params as $permission)
 		{
 			$result = $result && $authorize->hasPermission($permission, $authenticate->id());
 		}
-		
-        if (! $result)
-        {
-        	if ($authenticate->silent())
-        	{
+
+		if (! $result)
+		{
+			if ($authenticate->silent())
+			{
 				$redirectURL = session('redirect_url') ?? '/';
 				unset($_SESSION['redirect_url']);
 				return redirect()->to($redirectURL)->with('error', lang('Auth.notEnoughPrivilege'));
-        	}
-        	else {
-        		throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
-        	}
-        }
-    }
+			}
+			else {
+				throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
+			}
+		}
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    /**
-     * Allows After filters to inspect and modify the response
-     * object as needed. This method does not allow any way
-     * to stop execution of other after filters, short of
-     * throwing an Exception or Error.
-     *
-     * @param \CodeIgniter\HTTP\RequestInterface  $request
-     * @param \CodeIgniter\HTTP\ResponseInterface $response
-     *
-     * @return mixed
-     */
-    public function after(RequestInterface $request, ResponseInterface $response)
-    {
+	/**
+	 * Allows After filters to inspect and modify the response
+	 * object as needed. This method does not allow any way
+	 * to stop execution of other after filters, short of
+	 * throwing an Exception or Error.
+	 *
+	 * @param \CodeIgniter\HTTP\RequestInterface  $request
+	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 *
+	 * @return mixed
+	 */
+	public function after(RequestInterface $request, ResponseInterface $response)
+	{
 
-    }
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 }

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -7,76 +7,81 @@ use CodeIgniter\Filters\FilterInterface;
 
 class RoleFilter implements FilterInterface
 {
-    /**
-     * Do whatever processing this filter needs to do.
-     * By default it should not return anything during
-     * normal execution. However, when an abnormal state
-     * is found, it should return an instance of
-     * CodeIgniter\HTTP\Response. If it does, script
-     * execution will end and that Response will be
-     * sent back to the client, allowing for error pages,
-     * redirects, etc.
-     *
-     * @param \CodeIgniter\HTTP\RequestInterface $request
-     * @param array|null                         $params
-     *
-     * @return mixed
-     */
-    public function before(RequestInterface $request, $params = null)
-    {
+	/**
+	 * Do whatever processing this filter needs to do.
+	 * By default it should not return anything during
+	 * normal execution. However, when an abnormal state
+	 * is found, it should return an instance of
+	 * CodeIgniter\HTTP\Response. If it does, script
+	 * execution will end and that Response will be
+	 * sent back to the client, allowing for error pages,
+	 * redirects, etc.
+	 *
+	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param array|null                         $params
+	 *
+	 * @return mixed
+	 */
+	public function before(RequestInterface $request, $params = null)
+	{
+		if (! function_exists('logged_in'))
+		{
+			helper('auth');
+		}
+
 		if (empty($params))
 		{
 			return;
 		}
-		
-        $authenticate = Services::authentication();
-		
-		// if no user is logged in then send to the login form
-        if (! $authenticate->check())
-        {
-			session()->set('redirect_url', current_url());
-            return redirect('login');
-        }
 
-        $authorize = Services::authorization();
-		
+		$authenticate = Services::authentication();
+
+		// if no user is logged in then send to the login form
+		if (! $authenticate->check())
+		{
+			session()->set('redirect_url', current_url());
+			return redirect('login');
+		}
+
+		$authorize = Services::authorization();
+
 		// Check each requested permission
 		foreach ($params as $group)
 		{
-            if($authorize->inGroup($group, $authenticate->id()))
-            {
-                return;
-            }
+			if($authorize->inGroup($group, $authenticate->id()))
+			{
+				return;
+			}
 		}
-		
-    	if ($authenticate->silent())
-    	{
+
+		if ($authenticate->silent())
+		{
 			$redirectURL = session('redirect_url') ?? '/';
 			unset($_SESSION['redirect_url']);
 			return redirect()->to($redirectURL)->with('error', lang('Auth.notEnoughPrivilege'));
-    	}
-    	else {
-    		throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
-    	}
-    }
+		}
+		else {
+			throw new \RuntimeException(lang('Auth.notEnoughPrivilege'));
+		}
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
-    /**
-     * Allows After filters to inspect and modify the response
-     * object as needed. This method does not allow any way
-     * to stop execution of other after filters, short of
-     * throwing an Exception or Error.
-     *
-     * @param \CodeIgniter\HTTP\RequestInterface  $request
-     * @param \CodeIgniter\HTTP\ResponseInterface $response
-     *
-     * @return mixed
-     */
-    public function after(RequestInterface $request, ResponseInterface $response)
-    {
+	/**
+	 * Allows After filters to inspect and modify the response
+	 * object as needed. This method does not allow any way
+	 * to stop execution of other after filters, short of
+	 * throwing an Exception or Error.
+	 *
+	 * @param \CodeIgniter\HTTP\RequestInterface  $request
+	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 *
+	 * @return mixed
+	 */
+	public function after(RequestInterface $request, ResponseInterface $response)
+	{
 
-    }
+	}
 
-    //--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 }


### PR DESCRIPTION
This PR adds the helper to each filter so that filtered routes will have it loaded already. This is especially convenient for using module controllers that call app layouts which may have different displays for "logged out/in", etc.