### PR TITLE
Specify null return when no user

### DIFF
--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -300,7 +300,7 @@ class AuthenticationBase
      */
     public function id()
     {
-        return $this->user->id;
+        return $this->user->id ?? null;
     }
 
 


### PR DESCRIPTION
AuthenticationBase can return the current User ID via `id()` but it will fail if there is no logged in user because `$this->user` is null. This catches that case and returns null instead.