### PR TITLE
Default return URL to previous page

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -50,6 +50,9 @@ class AuthController extends Controller
 			return redirect()->to($redirectURL);
 		}
 
+        // Set a return URL if none is specified
+        $_SESSION['redirect_url'] = session('redirect_url') ?? previous_url() ?? '/';
+
 		echo view($this->config->views['login'], ['config' => $this->config]);
 	}
 
@@ -169,7 +172,7 @@ class AuthController extends Controller
 		{
 			$activator = Services::activator();
 			$sent = $activator->send($user);
-			
+
 			if (! $sent)
 			{
 				return redirect()->back()->withInput()->with('error', $activator->error() ?? lang('Auth.unknownError'));


### PR DESCRIPTION
Currently `redirect_url` is specified when using filters, but a direct link visit to `/login` will always return users to `/`. This PR directs `AuthController` to use `previous_url()` for the redirect if no other URL was specified. This is ideal for pages that don't *require* authentication but still display a link, e.g. "Log in to ...."