### PR TITLE
Modified AuthController->attemptRegister() validation rules

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -147,11 +147,12 @@ class AuthController extends Controller
 
 		// Validate here first, since some things,
 		// like the password, can only be validated properly here.
-		$rules = array_merge($users->getValidationRules(['only' => ['username']]), [
-			'email'		=> 'required|valid_email|is_unique[users.email]',
-			'password'	 => 'required|strong_password',
-			'pass_confirm' => 'required|matches[password]',
-		]);
+		$rules = [
+			'username'  	=> 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
+			'email'			=> 'required|valid_email|is_unique[users.email]',
+			'password'	 	=> 'required|strong_password',
+			'pass_confirm' 	=> 'required|matches[password]',
+		];
 
 		if (! $this->validate($rules))
 		{


### PR DESCRIPTION
Modified AuthController->attemptRegister() validation rules
from:
_$rules = array_merge($users->getValidationRules(['only' => ['username']]), [
			'email'		=> 'required|valid_email|is_unique[users.email]',
			'password'	 => 'required|strong_password',
			'pass_confirm' => 'required|matches[password]',
		]);_
to:
$rules = [
			'username'		=> 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
			'email'			=> 'required|valid_email|is_unique[users.email]',
			'password'	 	=> 'required|strong_password',
			'pass_confirm' 	=> 'required|matches[password]',
		];
because one of the validation rules for username returned by getValidationRules() method
is 'is_unique[users.username,id,{id}'. Specifying the optional 2nd and 3rd parameters will
make the validation library try to ignore the {id} value in the id column in the users table.
Since it is a registration process, the user still does not exist in the DB and its DB ID
can not be used to be ignored in the is_unique validation rule, therefore, throwing a DB error.