### PR TITLE
User entity in Validation Rules

### DIFF
--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -31,7 +31,7 @@ class ValidationRules
     public function strong_password(string $str, string &$error = null)
     {
         $checker = service('passwords');
-        $user = $this->buildUserFromRequest();
+        $user = (user()) ? user() : $this->buildUserFromRequest();
 
         $result = $checker->check($str, $user);
 

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -31,7 +31,7 @@ class ValidationRules
     public function strong_password(string $str, string &$error = null)
     {
         $checker = service('passwords');
-        $user = (user()) ? user() : $this->buildUserFromRequest();
+        $user = (function_exists("user") && user()) ? user() : $this->buildUserFromRequest();
 
         $result = $checker->check($str, $user);
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -45,6 +45,7 @@ class AuthController extends Controller
 		if ($this->auth->check())
 		{
 			$redirectURL = session('redirect_url') ?? '/';
+            if (site_url("login") === $redirectURL || site_url("logout") === $redirectURL) $redirectURL = site_url();
 			unset($_SESSION['redirect_url']);
 
 			return redirect()->to($redirectURL);
@@ -96,6 +97,7 @@ class AuthController extends Controller
 		}
 
 		$redirectURL = session('redirect_url') ?? '/';
+        if (site_url("login") === $redirectURL || site_url("logout") === $redirectURL) $redirectURL = site_url();
 		unset($_SESSION['redirect_url']);
 
 		return redirect()->to($redirectURL)->with('message', lang('Auth.loginSuccess'));

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -45,7 +45,6 @@ class AuthController extends Controller
 		if ($this->auth->check())
 		{
 			$redirectURL = session('redirect_url') ?? '/';
-            if (site_url("login") === $redirectURL || site_url("logout") === $redirectURL) $redirectURL = site_url();
 			unset($_SESSION['redirect_url']);
 
 			return redirect()->to($redirectURL);
@@ -97,7 +96,6 @@ class AuthController extends Controller
 		}
 
 		$redirectURL = session('redirect_url') ?? '/';
-        if (site_url("login") === $redirectURL || site_url("logout") === $redirectURL) $redirectURL = site_url();
 		unset($_SESSION['redirect_url']);
 
 		return redirect()->to($redirectURL)->with('message', lang('Auth.loginSuccess'));


### PR DESCRIPTION
In a scenario where a user is logged in, and we want to use the strong_password validation (for instance when forced to reset their password), use the user's entity. When not logged in build an entity from the request.