### PR TITLE
Fix the call for validation errors messages

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -160,7 +160,7 @@ class AuthController extends Controller
 
 		if (! $this->validate($rules))
 		{
-			return redirect()->back()->withInput()->with('errors', $users->errors());
+			return redirect()->back()->withInput()->with('errors', service('validation')->getErrors());
 		}
 
 		// Save the user


### PR DESCRIPTION
Use the same instance of the validator when checking for validation errors in `AuthController`.

We're validating these rules in the controller, so searching for validation errors through the model's instance of validation will not succeed.

Ref: #201