### PR TITLE
Support for assigning validation data to strong_password method

### DIFF
--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -23,14 +23,14 @@ class ValidationRules
      * better security if this is done manually, since you can
      * personalize based on a specific user at that point.
      *
-     * @param string $value Field value
-     * @param string $param Rule parameter (not used here)
-     * @param array  $data  Validation data array
-     * @param string $error Error that will be returned
+     * @param string $value  Field value
+     * @param string $error1 Error that will be returned (for call with validation data array)
+     * @param array  $data   Validation data array
+     * @param string $error2 Error that will be returned (for call without validation data array)
      *
      * @return bool
      */
-    public function strong_password(string $value, string $param = null, array $data = [], string &$error = null)
+    public function strong_password(string $value, string &$error1 = null, array $data = [], string &$error2 = null)
     {
         $checker = service('passwords');
 
@@ -47,7 +47,14 @@ class ValidationRules
 
         if ($result === false)
         {
-            $error = $checker->error();
+            if (empty($data))
+            {
+                $error1 = $checker->error();
+            }
+            else
+            {
+                $error2 = $checker->error();
+            }
         }
 
         return $result;

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -69,19 +69,7 @@ class ValidationRules
     {
         $fields = $this->prepareValidFields();
 
-        $request = service('request');
-
-        if (in_array($request->getMethod(), ['put', 'patch', 'delete']))
-        {
-            $data = $request->getRawInput();
-
-            $fields = array_fill_keys($fields, null);
-            $data = array_intersect_key(array_merge($fields, $data), $fields);
-        }
-        else
-        {
-            $data = $request->getVar($fields);
-        }
+        $data = service('request')->getPost($fields);
 
         return new User($data);
     }

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -23,17 +23,27 @@ class ValidationRules
      * better security if this is done manually, since you can
      * personalize based on a specific user at that point.
      *
-     * @param string      $str
-     * @param string|null $error
+     * @param string $value Field value
+     * @param string $param Rule parameter (not used here)
+     * @param array  $data  Validation data array
+     * @param string $error Error that will be returned
      *
      * @return bool
      */
-    public function strong_password(string $str, string &$error = null)
+    public function strong_password(string $value, string $param = null, array $data = [], string &$error = null)
     {
         $checker = service('passwords');
-        $user = (function_exists("user") && user()) ? user() : $this->buildUserFromRequest();
 
-        $result = $checker->check($str, $user);
+        if (function_exists('user') && user())
+        {
+            $user = user();
+        }
+        else
+        {
+            $user = empty($data) ? $this->buildUserFromRequest() : $this->buildUserFromData($data);
+        }
+
+        $result = $checker->check($value, $user);
 
         if ($result === false)
         {
@@ -46,17 +56,57 @@ class ValidationRules
     /**
      * Builds a new user instance from the global request.
      *
-     * @return User
+     * @return \Myth\Auth\Entities\User
      */
     protected function buildUserFromRequest()
+    {
+        $fields = $this->prepareValidFields();
+
+        $request = service('request');
+
+        if (in_array($request->getMethod(), ['put', 'patch', 'delete']))
+        {
+            $data = $request->getRawInput();
+
+            $fields = array_fill_keys($fields, null);
+            $data = array_intersect_key(array_merge($fields, $data), $fields);
+        }
+        else
+        {
+            $data = $request->getVar($fields);
+        }
+
+        return new User($data);
+    }
+
+    /**
+     * Builds a new user instance from assigned data..
+     *
+     * @param array $data Assigned data
+     *
+     * @return \Myth\Auth\Entities\User
+     */
+    protected function buildUserFromData(array $data = [])
+    {
+        $fields = $this->prepareValidFields();
+
+        $data = array_intersect_key($data, array_fill_keys($fields, null));
+
+        return new User($data);
+    }
+
+    /**
+     * Prepare valid user fields
+     *
+     * @return array
+     */
+    protected function prepareValidFields(): array
     {
         $config = config('Auth');
         $fields = array_merge($config->validFields, $config->personalFields);
         $fields[] = 'password';
 
-        $data = service('request')->getPost($fields);
-
-        return new User($data);
+        return $fields;
     }
 
 }

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -24,9 +24,9 @@ class ValidationRules
      * personalize based on a specific user at that point.
      *
      * @param string $value  Field value
-     * @param string $error1 Error that will be returned (for call with validation data array)
+     * @param string $error1 Error that will be returned (for call without validation data array)
      * @param array  $data   Validation data array
-     * @param string $error2 Error that will be returned (for call without validation data array)
+     * @param string $error2 Error that will be returned (for call with validation data array)
      *
      * @return bool
      */

--- a/tests/unit/ValidationRulesTest.php
+++ b/tests/unit/ValidationRulesTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Validation\Validation;
+use Config\Services;
+use Myth\Auth\Authentication\Passwords\ValidationRules;
+
+
+class ValidationRulesTest extends CIUnitTestCase
+{
+    protected $validation;
+    protected $config = [
+        'ruleSets'      => [
+            ValidationRules::class,
+        ],
+    ];
+
+    //--------------------------------------------------------------------
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Services::reset(true);
+
+        $this->validation = new Validation((object) $this->config, \Config\Services::renderer());
+        $this->validation->reset();
+
+        $_REQUEST = [];
+    }
+
+    //--------------------------------------------------------------------
+
+    public function testStrongPasswordLongRule()
+    {
+        $rules = [
+            'password' => 'strong_password[]',
+        ];
+
+        $data = [
+            'email'    => 'john@smith.com',
+            'password' => '!!!gerard!!!abootylicious',
+        ];
+
+        $this->validation->setRules($rules);
+
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    //--------------------------------------------------------------------
+
+    public function testStrongPasswordLongRuleWithPostRequest()
+    {
+        $_REQUEST = $data = [
+            'email'    => 'john@smith.com',
+            'password' => '!!!gerard!!!abootylicious',
+        ];
+
+        $request = service('request');
+        $request->setMethod('post')->setGlobal('post', $data);
+
+        $this->validation->setRules([
+            'password' => 'strong_password[]',
+        ]);
+
+        $result = $this->validation->withRequest($request)->run();
+        $this->assertTrue($result);
+    }
+
+    //--------------------------------------------------------------------
+
+    public function testStrongPasswordLongRuleWithRawInputRequest()
+    {
+        $data = [
+            'email'    => 'john@smith.com',
+            'password' => '!!!gerard!!!abootylicious',
+        ];
+
+        $request = service('request');
+        $request->setMethod('patch')->setBody(http_build_query($data));
+
+        $this->validation->setRules([
+            'password' => 'strong_password[]',
+        ]);
+
+        $result = $this->validation->withRequest($request)->run();
+        $this->assertTrue($result);
+    }
+
+    //--------------------------------------------------------------------
+
+    public function testStrongPasswordShortRuleWithPostRequest()
+    {
+        $_REQUEST = $data = [
+            'email'    => 'john@smith.com',
+            'password' => '!!!gerard!!!abootylicious',
+        ];
+
+        $request = service('request');
+        $request->setMethod('post')->setGlobal('post', $data);
+
+        $this->validation->setRules([
+            'password' => 'strong_password',
+        ]);
+
+        $result = $this->validation->withRequest($request)->run();
+        $this->assertTrue($result);
+    }
+
+    //--------------------------------------------------------------------
+
+    public function testStrongPasswordShortRuleWithRawInputRequest()
+    {
+        $data = [
+            'email'    => 'john@smith.com',
+            'password' => '!!!gerard!!!abootylicious',
+        ];
+
+        $request = service('request');
+        $request->setMethod('patch')->setBody(http_build_query($data));
+
+        $this->validation->setRules([
+            'password' => 'strong_password',
+        ]);
+
+        $result = $this->validation->withRequest($request)->run();
+        $this->assertTrue($result);
+    }
+
+}


### PR DESCRIPTION
This PR makes it possible to take parameters from the validation data array or just like before when this parameter is not available from request.

I made changes that will work in both cases. When using `strong_password` everything is working as before but when using `strong_password[]` we will use data provided by the validation class.

This will work even if in the future CodeIgniter will pass validation data to the rules without a need of using a special syntax `[]`.

This approach doesn't break any compatibility for people who use `strong_password` right now, so it can be safely used without the need for changes in the developer's code.