### PR TITLE
Make resetting password more customizable

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -220,6 +220,23 @@ by `requireActivation` config variable.
         ],
     ];
 
+### auth.activeResetter
+This can be either false or string with a namespaced class name. Using a class name will force `resetter` service to use this
+ class to send a reset message.
+
+	public $activeResetter = 'Myth\Auth\Authentication\Resetters\EmailResetter';
+
+### auth.userResetters
+This is a list of available resetters, along with their optional configuration variables. Class names listed here can be used
+by `activeResetter` config variable.
+
+	public $userResetters = [
+        'Myth\Auth\Authentication\Resetters\EmailResetter' => [
+            'fromEmail' => null,
+            'fromName' => null,
+        ],
+    ];
+
 ### auth.allowRemembering
 This can be either true or false, and determines whether or not the system allows persistent logins (Remember Me). 
 For most sites, you will likely want this turned on for your user's convenience. If your site holds extremely 

--- a/src/Authentication/Resetters/BaseResetter.php
+++ b/src/Authentication/Resetters/BaseResetter.php
@@ -1,0 +1,31 @@
+<?php namespace Myth\Auth\Authentication\Resetters;
+
+class BaseResetter
+{
+    protected $config;
+
+    /**
+     * Allows for setting a config file on the Resetter.
+     *
+     * @param $config
+     *
+     * @return $this
+     */
+    public function setConfig($config)
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * Gets a config settings for current Resetter.
+     *
+     * @return $array
+     */
+    public function getResetterSettings()
+    {
+        return (object) $this->config->userResetters[get_class($this)];
+    }
+
+}

--- a/src/Authentication/Resetters/EmailResetter.php
+++ b/src/Authentication/Resetters/EmailResetter.php
@@ -1,0 +1,61 @@
+<?php namespace Myth\Auth\Authentication\Resetters;
+
+use Config\Email;
+use CodeIgniter\Entity;
+use CodeIgniter\Config\Services;
+
+/**
+ * Class EmailResetter
+ *
+ * Sends a reset password email to user.
+ *
+ * @package Myth\Auth\Authentication\Resetters
+ */
+class EmailResetter extends BaseResetter implements ResetterInterface
+{
+    /**
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * Sends a reset email
+     *
+     * @param User $user
+     *
+     * @return mixed
+     */
+    public function send(Entity $user = null): bool
+    {
+        $email = Services::email();
+        $config = new Email();
+
+        $settings = $this->getResetterSettings();
+
+        $sent = $email->setFrom($settings->fromEmail ?? $config->fromEmail, $settings->fromName ?? $config->fromName)
+              ->setTo($user->email)
+              ->setSubject(lang('Auth.forgotSubject'))
+              ->setMessage(view($this->config->views['emailForgot'], ['hash' => $user->reset_hash]))
+              ->setMailType('html')
+              ->send();
+
+        if (! $sent)
+        {
+            $this->error = lang('Auth.errorEmailSent', [$user->email]);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the error string that should be displayed to the user.
+     *
+     * @return string
+     */
+    public function error(): string
+    {
+        return $this->error ?? '';
+    }
+
+}

--- a/src/Authentication/Resetters/ResetterInterface.php
+++ b/src/Authentication/Resetters/ResetterInterface.php
@@ -1,0 +1,28 @@
+<?php namespace Myth\Auth\Authentication\Resetters;
+
+use CodeIgniter\Entity;
+
+/**
+ * Interface ResetterInterface
+ *
+ * @package Myth\Auth\Authentication\Resetters
+ */
+interface ResetterInterface
+{
+    /**
+     * Send reset message to user
+     *
+     * @param User $user
+     *
+     * @return mixed
+     */
+    public function send(Entity $user = null): bool;
+
+    /**
+     * Returns the error string that should be displayed to the user.
+     *
+     * @return string
+     */
+    public function error(): string;
+
+}

--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -1,0 +1,61 @@
+<?php namespace Myth\Auth\Authentication\Resetters;
+
+use Myth\Auth\Config\Auth;
+use Myth\Auth\Entities\User;
+
+class UserResetter
+{
+    /**
+     * @var Auth
+     */
+    protected $config;
+
+    protected $error;
+
+    public function __construct(Auth $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Sends reset message to the user via specified class
+     * in `$activeResetter` setting in Config\Auth.php.
+     *
+     * @param User $user
+     *
+     * @return bool
+     */
+    public function send(User $user = null): bool
+    {
+        if ($this->config->activeResetter === false)
+        {
+            return true;
+        }
+
+        $className = $this->config->activeResetter;
+
+        $class = new $className();
+        $class->setConfig($this->config);
+
+        if ($class->send($user) === false)
+        {
+            log_message('error', "Failed to send reset messaage to: {$user->email}");
+            $this->error = $class->error();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the current error.
+     *
+     * @return mixed
+     */
+    public function error()
+    {
+        return $this->error;
+    }
+
+}

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -116,6 +116,14 @@ class Auth extends BaseConfig
     public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
 
     //--------------------------------------------------------------------
+    // Allow to reset password via email
+    //--------------------------------------------------------------------
+    // When enabled, every user will have the option to reset his password
+    // via specified resetter. Default setting is email.
+    //
+    public $activeResetter = 'Myth\Auth\Authentication\Resetters\EmailResetter';
+
+    //--------------------------------------------------------------------
     // Allow Persistent Login Cookies (Remember me)
     //--------------------------------------------------------------------
     // While every attempt has been made to create a very strong protection
@@ -217,6 +225,18 @@ class Auth extends BaseConfig
     //
     public $userActivators = [
         'Myth\Auth\Authentication\Activators\EmailActivator' => [
+            'fromEmail' => null,
+            'fromName' => null,
+        ],
+    ];
+
+    //--------------------------------------------------------------------
+    // Resetter classes
+    //--------------------------------------------------------------------
+    // Available resetters with config settings
+    //
+    public $userResetters = [
+        'Myth\Auth\Authentication\Resetters\EmailResetter' => [
             'fromEmail' => null,
             'fromName' => null,
         ],

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -8,6 +8,7 @@ use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
 use Myth\Auth\Authentication\Passwords\PasswordValidator;
 use Myth\Auth\Authentication\Activators\UserActivator;
+use Myth\Auth\Authentication\Resetters\UserResetter;
 use Config\Services as BaseService;
 
 class Services extends BaseService
@@ -112,5 +113,28 @@ class Services extends BaseService
         }
 
         return new UserActivator($config);
+    }
+
+    /**
+     * Returns an instance of the resetter.
+     *
+     * @param null $config
+     * @param bool $getShared
+     *
+     * @return mixed|Activator
+     */
+    public static function resetter($config = null, bool $getShared = true)
+    {
+        if ($getShared)
+        {
+            return self::getSharedInstance('resetter', $config);
+        }
+
+        if (empty($config))
+        {
+            $config = config(Auth::class);
+        }
+
+        return new UserResetter($config);
     }
 }

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -31,10 +31,12 @@ return [
     'invalidPassword'           => 'Unable to log you in. Please check your password.',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.',
     'forgotNoUser'              => 'Unable to locate a user with that email.',
     'forgotSubject'             => 'Password Reset Instructions',
     'resetSuccess'              => 'Your password has been successfully changed. Please login with the new password.',
     'forgotEmailSent'           => 'A security token has been emailed to you. Enter it in the box below to continue.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}',
 
     // Passwords
     'errorPasswordLength'       => 'Passwords must be at least {0, number} characters long.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -31,10 +31,12 @@ return [
     'invalidPassword'           => 'No se pudo ingresar al sistema. Por favor, chequee sus credenciales.',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
     'forgotNoUser'              => 'No se pudo localizar un usuario con ese correo electrónico.',
     'forgotSubject'             => 'Instrucciones para resetear la contraseña',
     'resetSuccess'              => 'El cambio de contraseña fue correcto. Por favor ingrese con su nueva contraseña.',
     'forgotEmailSent'           => 'Se ha enviado un código de seguridad a su e-mail. Ingréselo en el cuadro siguiente para continuar.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'La contraseña debe tener al menos {0, number} caracteres.',

--- a/src/Language/it/Auth.php
+++ b/src/Language/it/Auth.php
@@ -31,10 +31,12 @@ return [
     'invalidPassword'           => 'Impossibile accedere. Verifica la password.',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Impossibile trovare un utente con questo indirizzo email.',
     'forgotSubject'             => 'Istruzioni per il Ripristino della Password',
     'resetSuccess'              => 'La tua password è stata cambiata con successo. Effettua l\'accesso con le tue nuove credenziali.',
     'forgotEmailSent'           => 'Un token di sicurezza è stato inviato al tuo indirizzo email. Inseriscilo nella casella qui sotto per continuare.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'La password deve contenere almeno {0, number} caratteri.',

--- a/src/Language/pt-BR/Auth.php
+++ b/src/Language/pt-BR/Auth.php
@@ -30,10 +30,12 @@ return [
     'loginSuccess'              => 'Bem-vindo de volta!',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Não foi possível localizar um  usuário com esse e-mail.',
     'forgotSubject'             => 'Instruções de redefinição de senha',
     'resetSuccess'              => 'Sua senha foi alterada com sucesso. Por favor, entre com sua nova senha.',
     'forgotEmailSent'           => 'Um token de segurança foi enviado para o seu e-mail. Cole-o no campo abaixo para continuar.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'A senha deve conter pelo menos {0, number} caracteres.',

--- a/src/Language/ru/Auth.php
+++ b/src/Language/ru/Auth.php
@@ -29,10 +29,12 @@ return [
     'loginSuccess'              => 'С возвращением!',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Не удалось найти пользователя с этим email.',
     'forgotSubject'             => 'Восстановление пароля',
     'resetSuccess'              => 'Ваш пароль был успешно изменен. Пожалуйста, войдите, используя новый пароль.',
     'forgotEmailSent'           => 'Токен безопасности был отправлен на ваш email. Введите его в поле ниже.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'Длина пароля должна быть не менее {0, number} символов(а).',

--- a/src/Language/tr/Auth.php
+++ b/src/Language/tr/Auth.php
@@ -31,10 +31,12 @@ return [
     'invalidPassword'           => 'Giriş yapılamıyor. Lütfen bilgilerinizi kontrol edin.',
 
     // Forgotten Passwords
+    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Bu emaile sahip bir kullanıcı bulunamıyor.',
     'forgotSubject'             => 'Parola Sıfırlama Adımları',
     'resetSuccess'              => 'Parolanız başarıyla değiştirildi. Yeni parolanızla giriş yapabilirsiniz.',
     'forgotEmailSent'           => 'Email adresinize bir güvenlik kodu gönderildi. Devam etmek için bu kodu aşağıdaki alana girin.',
+    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'Parola en az {0, number} karakter uzunluğunda olmalıdır.',

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -61,7 +61,9 @@
 <?php if ($config->allowRegistration) : ?>
 					<p><a href="<?= route_to('register') ?>"><?=lang('Auth.needAnAccount')?></a></p>
 <?php endif; ?>
+<?php if ($config->activeResetter): ?>
 					<p><a href="<?= route_to('forgot') ?>"><?=lang('Auth.forgotYourPassword')?></a></p>
+<?php endif; ?>
 				</div>
 			</div>
 


### PR DESCRIPTION
This PR make reset password more customizable. It works the same way as the activators.

I can imagine a scenario when resetting a password would be allowed only with ie. SMS message, so these changes will make it easy to customize the delivery channel.