### PR TITLE
Filter post data on registration

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -164,7 +164,8 @@ class AuthController extends Controller
 		}
 
 		// Save the user
-		$user = new User($this->request->getPost());
+		$allowedPostFields = array_merge(['username', 'email', 'password'], $this->config->personalFields);
+		$user = new User($this->request->getPost($allowedPostFields));
 
 		$this->config->requireActivation !== false ? $user->generateActivateHash() : $user->activate();
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -164,7 +164,7 @@ class AuthController extends Controller
 		}
 
 		// Save the user
-		$allowedPostFields = array_merge(['username', 'email', 'password'], $this->config->personalFields);
+		$allowedPostFields = array_merge(['password'], $this->config->validFields, $this->config->personalFields);
 		$user = new User($this->request->getPost($allowedPostFields));
 
 		$this->config->requireActivation !== false ? $user->generateActivateHash() : $user->activate();


### PR DESCRIPTION
We should filter data we pass to the User entity during registration since otherwise someone could send additional `POST` data like `active` and bypass the need of the account activation.