### PR TITLE
Add Fakers to source

### DIFF
--- a/src/Test/Fakers/GroupFaker.php
+++ b/src/Test/Fakers/GroupFaker.php
@@ -1,0 +1,22 @@
+<?php namespace Myth\Auth\Test\Fakers;
+
+use Faker\Generator;
+use Myth\Auth\Authorization\GroupModel;
+
+class GroupFaker extends GroupModel
+{
+	/**
+	 * Faked data for Fabricator.
+	 *
+	 * @param Generator $faker
+	 *
+	 * @return object
+	 */
+	public function fake(Generator &$faker): \stdClass
+	{
+		return (object) [
+            'name'        => $faker->word,
+            'description' => $faker->sentence,
+		];
+	}
+}

--- a/src/Test/Fakers/PermissionFaker.php
+++ b/src/Test/Fakers/PermissionFaker.php
@@ -1,0 +1,22 @@
+<?php namespace Myth\Auth\Test\Fakers;
+
+use Faker\Generator;
+use Myth\Auth\Authorization\PermissionModel;
+
+class PermissionFaker extends PermissionModel
+{
+	/**
+	 * Faked data for Fabricator.
+	 *
+	 * @param Generator $faker
+	 *
+	 * @return array
+	 */
+	public function fake(Generator &$faker): array
+	{
+		return [
+            'name'        => $faker->word,
+            'description' => $faker->sentence,
+		];
+	}
+}

--- a/src/Test/Fakers/UserFaker.php
+++ b/src/Test/Fakers/UserFaker.php
@@ -1,0 +1,24 @@
+<?php namespace Myth\Auth\Test\Fakers;
+
+use Faker\Generator;
+use Myth\Auth\Entities\User;
+use Myth\Auth\Models\UserModel;
+
+class UserFaker extends UserModel
+{
+	/**
+	 * Faked data for Fabricator.
+	 *
+	 * @param Generator $faker
+	 *
+	 * @return Myth\Auth\Entities\User
+	 */
+	public function fake(Generator &$faker): User
+	{
+		return new User([
+			'email'         => $faker->email,
+			'username'      => implode('_', $faker->words),
+			'password'      =>  bin2hex(random_bytes(16)),
+		]);
+	}
+}

--- a/tests/_support/AuthTestCase.php
+++ b/tests/_support/AuthTestCase.php
@@ -5,6 +5,10 @@ use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
+use Myth\Auth\Test\Fakers\GroupFaker;
+use Myth\Auth\Test\Fakers\PermissionFaker;
+use Myth\Auth\Test\Fakers\UserFaker;
+use CodeIgniter\Test\Fabricator;
 use CodeIgniter\Test\Mock\MockSession;
 
 class AuthTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
@@ -52,6 +56,9 @@ class AuthTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
      */
 	protected $permissions;
 
+	/**
+	 * @var Faker\Generator
+	 */
 	protected $faker;
 
 	/**
@@ -99,13 +106,14 @@ class AuthTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
 			'password' => 'secret'
 		];
 		$info = array_merge($defaults, $info);
-		$user = new User($info);
 
-		$userId = $this->users->insert($user);
-		$user = $this->users->find($userId);
+		$fabricator = new Fabricator(UserFaker::class);
+		$fabricator->setOverrides($info, false);
+
+		$user = $fabricator->create();
 
 		// Delete any cached permissions
-        cache()->delete("{$userId}_permissions");
+        cache()->delete($user->id . '_permissions');
 
 		return $user;
 	}
@@ -119,15 +127,10 @@ class AuthTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
      */
 	protected function createGroup(array $info = [])
     {
-        $defaults = [
-            'name' => $this->faker->word,
-            'description' => $this->faker->sentence
-        ];
-        $info = array_merge($defaults, $info);
+		$fabricator = new Fabricator(GroupFaker::class);
+		$fabricator->setOverrides($info, false);
 
-        $this->db->table('auth_groups')->insert($info);
-
-        return $this->db->table('auth_groups')->where('id', $this->db->insertID())->get()->getResultObject()[0];
+        return $fabricator->create();
     }
 
     /**
@@ -139,14 +142,9 @@ class AuthTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
      */
     protected function createPermission(array $info = [])
     {
-        $defaults = [
-            'name' => $this->faker->word,
-            'description' => $this->faker->sentence
-        ];
-        $info = array_merge($defaults, $info);
+		$fabricator = new Fabricator(PermissionFaker::class);
+		$fabricator->setOverrides($info, false);
 
-        $this->db->table('auth_permissions')->insert($info);
-
-        return $this->db->table('auth_permissions')->where('id', $this->db->insertID())->get()->getResultObject()[0];
+        return (object) $fabricator->create();
     }
 }

--- a/tests/unit/FakersTest.php
+++ b/tests/unit/FakersTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use CodeIgniter\Test\Fabricator;
+use ModuleTests\Support\AuthTestCase;
+use Myth\Auth\Entities\User;
+use Myth\Auth\Test\Fakers\GroupFaker;
+use Myth\Auth\Test\Fakers\UserFaker;
+
+class FakersTest extends AuthTestCase
+{
+    public function testUserFakerReturnsUser()
+    {
+		$fabricator = new Fabricator(UserFaker::class);
+		$user       = $fabricator->make();
+
+		$this->assertInstanceOf(User::class, $user);
+    }
+
+    public function testUserFakerCreatesUser()
+    {
+		$fabricator = new Fabricator(UserFaker::class);
+		$user       = $fabricator->create();
+
+		$this->seeInDatabase('users', ['email' => $user->email]);
+    }
+
+    public function testGroupFakerReturnsObject()
+    {
+		$fabricator = new Fabricator(GroupFaker::class);
+		$group      = $fabricator->make();
+
+		$this->assertIsObject($group);
+    }
+
+    public function testGroupFakerCreatesGroup()
+    {
+		$fabricator = new Fabricator(GroupFaker::class);
+		$group      = $fabricator->create();
+
+		$this->seeInDatabase('auth_groups', ['name' => $group->name]);
+    }
+}


### PR DESCRIPTION
* Implements the new Fabricator class in developer-available `Test\Fakers`
* Updates `AuthTestCase` to use the Fabricator with these fakers

**Note**: `Myth\Auth` is still using legacy `ModuleTests` and should be updated. I didn't notice it until part way in and it would conflict with this PR. Let's get through this and then do that.
