### PR TITLE
Clear user property on logout

### DIFF
--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -168,30 +168,34 @@ class AuthenticationBase
     {
         helper('cookie');
 
-        $user = $this->user();
-
         // Destroy the session data - but ensure a session is still
         // available for flash messages, etc.
         if (isset($_SESSION))
         {
-            foreach ( $_SESSION as $key => $value )
+            foreach ($_SESSION as $key => $value)
             {
-                $_SESSION[ $key ] = NULL;
-                unset( $_SESSION[ $key ] );
+                $_SESSION[$key] = NULL;
+                unset($_SESSION[$key]);
             }
         }
 
         // Regenerate the session ID for a touch of added safety.
         session()->regenerate(true);
 
-        // Take care of any remember me functionality
-        $this->loginModel->purgeRememberTokens($user->id);
-
         // Remove the cookie
         delete_cookie("remember");
 
-        // trigger logout event
-		Events::trigger('logout', $user);
+        // Handle user-specific tasks
+        if ($user = $this->user())
+        {
+            // Take care of any remember me functionality
+            $this->loginModel->purgeRememberTokens($user->id);
+
+            // Trigger logout event
+            Events::trigger('logout', $user);
+
+            $this->user = null;
+        }
     }
 
     /**

--- a/tests/authentication/AuthenticationBaseTest.php
+++ b/tests/authentication/AuthenticationBaseTest.php
@@ -109,4 +109,15 @@ class AuthenticationBaseTest extends AuthTestCase
         ]);
     }
 
+    public function testLogoutLogsOut()
+    {
+        $user = $this->createUser();
+
+        $this->assertTrue($this->auth->login($user));
+
+		$this->auth->logout();
+
+        $this->assertFalse($this->auth->isLoggedIn());
+        $this->assertNull($this->auth->user());
+    }
 }


### PR DESCRIPTION
Fixes a bug where logging out doesn't actually remove the `$user` property from the authentication class, causing certain methods to continue to act as though the user is logged in.