### PR TITLE
Add getUsersForGroup

### DIFF
--- a/src/Authorization/GroupModel.php
+++ b/src/Authorization/GroupModel.php
@@ -85,7 +85,7 @@ class GroupModel extends Model
      *
      * @param $userId
      *
-     * @return object
+     * @return array
      */
     public function getGroupsForUser(int $userId)
     {
@@ -103,6 +103,29 @@ class GroupModel extends Model
         return $found;
     }
 
+    /**
+     * Returns an array of all users that are members of a group.
+     *
+     * @param $groupId
+     *
+     * @return array
+     */
+    public function getUsersForGroup(int $groupId)
+    {
+        if (! $found = cache("{$groupId}_users"))
+        {
+            $found = $this->builder()
+                ->select('auth_groups_users.*, users.*')
+                ->join('auth_groups_users', 'auth_groups_users.group_id = auth_groups.id', 'left')
+                ->join('users', 'auth_groups_users.user_id = users.id', 'left')
+                ->where('auth_groups.id', $groupId)
+                ->get()->getResultArray();
+
+            cache()->save("{$groupId}_users", $found, 300);
+        }
+
+        return $found;
+    }
 
     //--------------------------------------------------------------------
     // Permissions

--- a/tests/authorization/GroupModelTest.php
+++ b/tests/authorization/GroupModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Myth\Auth\Authorization\GroupModel;
+use Myth\Auth\Test\Fakers\UserFaker;
 use Tests\Support\AuthTestCase;
 
 class GroupModelTest extends AuthTestCase
@@ -118,6 +119,27 @@ class GroupModelTest extends AuthTestCase
             'name' => $group2->name,
             'description' => $group2->description
         ]);
+    }
+
+    public function testGetUsersForGroup()
+    {
+        $group = $this->createGroup();
+        $user1 = fake(UserFaker::class);
+        $user2 = fake(UserFaker::class);
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user1->id,
+            'group_id' => $group->id
+        ]);
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user2->id,
+            'group_id' => $group->id
+        ]);
+
+        $result = $this->model->getUsersForGroup($group->id);
+
+        $this->assertEquals($user1->id, $result[0]['id']);
+        $this->assertEquals($user2->id, $result[1]['id']);
     }
 
     public function testAddPermissionToGroup()


### PR DESCRIPTION
Includes a simple converse method to `GroupModel::getGroupsForUser` to fetch all the users in a specific group.