### PR TITLE
Add test trait

### DIFF
--- a/src/Test/AuthTestTrait.php
+++ b/src/Test/AuthTestTrait.php
@@ -1,0 +1,23 @@
+<?php namespace Myth\Auth\Test;
+
+use Config\Services;
+
+/**
+ * Trait AuthTestTrait
+ *
+ * Provides additional utilities for authentication and authorization
+ * during testing.
+ */
+trait AuthTestTrait
+{
+    /**
+     * Resets the Authentication and Authorization services.
+     * Particularly helpful between feature tests.
+     */
+	protected function resetAuthServices()
+	{
+		Services::injectMock('authentication', Services::authentication('local', null, null, false));
+		Services::injectMock('authorization',  Services::authorization(null, null, null, false));
+		$_SESSION = [];
+	}
+}

--- a/tests/unit/AuthTestTraitTest.php
+++ b/tests/unit/AuthTestTraitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Myth\Auth\Test\Fakers\PermissionFaker;
+use Myth\Auth\Test\Fakers\UserFaker;
+use Tests\Support\AuthTestCase;
+
+class AuthTestTraitTest extends AuthTestCase
+{
+	use \Myth\Auth\Test\AuthTestTrait;
+
+	public function testResetServicesResetsAuthentication()
+	{
+		$authentication = service('authentication');
+
+		$user = fake(UserFaker::class);
+
+		$authentication->login($user);
+		$this->assertTrue($authentication->isLoggedIn());
+
+		$this->resetAuthServices();
+
+		$this->assertFalse(service('authentication')->check());
+	}
+
+	public function testResetServicesResetsAuthorization()
+	{
+		$authorization = service('authorization');
+		$authorization->setUserModel(model(UserFaker::class));
+
+		$this->resetAuthServices();
+
+		$authorization = service('authorization');
+		$model         = $this->getPrivateProperty($authorization, 'userModel');
+
+		$this->assertNotInstanceOf(UserFaker::class, $model);
+	}
+}


### PR DESCRIPTION
I have a lot more things I'd like to see in this trait, but this one is pressing. The Auth services don't automatically reset to session values between tests, so unless they are loaded or mocked manually they will use stale values. This is particularly troublesome for feature testing with filters (see also: https://github.com/codeigniter4/CodeIgniter4/issues/3085).

This PR adds the trait class itself and `resetAuthServices()` to help with clearing Auth and session data between tests.