### PR TITLE
Delete permissions cache with groups cache in GroupModel

### DIFF
--- a/src/Authorization/GroupModel.php
+++ b/src/Authorization/GroupModel.php
@@ -36,6 +36,7 @@ class GroupModel extends Model
     public function addUserToGroup(int $userId, int $groupId)
     {
         cache()->delete("{$userId}_groups");
+        cache()->delete("{$userId}_permissions");
 
         $data = [
             'user_id'   => (int)$userId,
@@ -56,6 +57,7 @@ class GroupModel extends Model
     public function removeUserFromGroup(int $userId, $groupId)
     {
         cache()->delete("{$userId}_groups");
+        cache()->delete("{$userId}_permissions");
 
         return $this->db->table('auth_groups_users')
             ->where([
@@ -74,6 +76,7 @@ class GroupModel extends Model
     public function removeUserFromAllGroups(int $userId)
     {
         cache()->delete("{$userId}_groups");
+        cache()->delete("{$userId}_permissions");
 
         return $this->db->table('auth_groups_users')
             ->where('user_id', (int)$userId)


### PR DESCRIPTION
Hey, I have an issue where the permissions of a user were still retrieved even after having removed them from a group. There is an issue already open regarding permissions cache (https://github.com/lonnieezell/myth-auth/issues/239), so I figured I'd fix it.

Thanks for myth-auth by the way, great package!