### PR TITLE
Add test method, test docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,50 @@
+# Testing
+
+**Myth:Auth** comes with a few classes to assist with testing authentication in your app.
+All test classes are in the `Myth\Auth\Test` namespace and should be ignored in a
+production environment.
+
+## Fakers
+
+Fakers are `Model` extensions pre-configured to generate random Entities to be used with
+CodeIgniter's `Fabricator` class. These are very handy during testing if you want to create
+an object on-the-fly:
+
+```
+use CodeIgniter\Test\CIUnitTestCase;
+use Myth\Auth\Test\Fakers\UserFaker;
+
+class AuthTest extends CIUnitTestCase
+{
+	public testUserCanFoo
+	{
+		helper('test');
+
+		$user = fake(UserFaker::class);
+
+		$this->assertTrue($user->can('foo'));
+	}
+}
+```
+
+The following Fakers are available, corresponding to library models:
+* `GroupFaker`
+* `PermissionFaker`
+* `UserFaker`.
+
+## AuthTestTrait
+
+A trait you may add to your Test Case that provides some convenience methods that are
+particularly useful during Feature Testing.
+
+> Tip: Because these method require no parameters you may add them to your Test Case's `$setUpMethods` for automated execution
+
+**createAuthUser(bool $login = true, array $overrides = []): User**
+
+Creates a new random `User` from the `UserFaker` and any `$overrides` data provided.
+If `$login` is true (default) it will log in the new user. Returns the new `User` entity.
+
+**resetAuthServices()**
+
+Resets the Authentication and Authorization services. Particularly handy to make sure all
+auth data is cleared between test calls.

--- a/src/Test/AuthTestTrait.php
+++ b/src/Test/AuthTestTrait.php
@@ -1,6 +1,9 @@
 <?php namespace Myth\Auth\Test;
 
+use CodeIgniter\Test\Fabricator;
 use Config\Services;
+use Myth\Auth\Entities\User;
+use Myth\Auth\Test\Fakers\UserFaker;
 
 /**
  * Trait AuthTestTrait
@@ -10,6 +13,45 @@ use Config\Services;
  */
 trait AuthTestTrait
 {
+    /**
+     * Creates a new faked User, optionally logging them in.
+     *
+     * @param bool $login      Whether to log in the new User
+     * @param array $overrides Overriding data for the Fabricator
+     *
+     * @return User
+     * @throws \RuntimeException Usually only if overriding data fails to validate
+     */
+	protected function createAuthUser(bool $login = true, array $overrides = []): User
+	{
+		$fabricator = new Fabricator(UserFaker::class);
+
+		// Set overriding data, if necessary
+		if (! empty($overrides))
+		{
+			$fabricator->setOverrides($overrides);
+		}
+
+		$user = $fabricator->make();
+		$user->activate();
+
+		if (! model(UserFaker::class)->insert($user))
+		{
+			$error = implode(' ', model(UserFaker::class)->errors());
+
+			throw new \RuntimeException('Unable to create user: ' . $error);
+		}
+
+		if ($login)
+		{
+			$auth = Services::authentication();
+			$auth->login($user);
+			Services::injectMock('authentication', $auth);
+		}
+
+		return $user;
+	}
+
     /**
      * Resets the Authentication and Authorization services.
      * Particularly helpful between feature tests.

--- a/src/Test/Fakers/UserFaker.php
+++ b/src/Test/Fakers/UserFaker.php
@@ -11,14 +11,14 @@ class UserFaker extends UserModel
 	 *
 	 * @param Generator $faker
 	 *
-	 * @return Myth\Auth\Entities\User
+	 * @return User
 	 */
 	public function fake(Generator &$faker): User
 	{
 		return new User([
-			'email'         => $faker->email,
-			'username'      => implode('_', $faker->words),
-			'password'      =>  bin2hex(random_bytes(16)),
+			'email'    => $faker->email,
+			'username' => implode('_', $faker->words),
+			'password' => bin2hex(random_bytes(16)),
 		]);
 	}
 }

--- a/tests/unit/AuthTestTraitTest.php
+++ b/tests/unit/AuthTestTraitTest.php
@@ -34,4 +34,13 @@ class AuthTestTraitTest extends AuthTestCase
 
 		$this->assertNotInstanceOf(UserFaker::class, $model);
 	}
+
+	public function testCreateAuthUser()
+	{
+		$user = $this->createAuthUser();
+		$this->seeInDatabase('users', ['email' => $user->email]);
+
+		$authentication = service('authentication');
+		$this->assertTrue($authentication->isLoggedIn());
+	}
 }


### PR DESCRIPTION
* Adds a new convenience method to `AuthTestTrait`, "createAuthUser", which will create a new faked User and (optionally) log it in
* Begins docs for the various Test classes
