### PR TITLE
Active resetter type

### DIFF
--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -27,7 +27,7 @@ class UserResetter
      */
     public function send(User $user = null): bool
     {
-        if ($this->config->activeResetter === false)
+        if (! $this->config->activeResetter)
         {
             return true;
         }

--- a/src/Authorization/FlatAuthorization.php
+++ b/src/Authorization/FlatAuthorization.php
@@ -12,17 +12,29 @@ class FlatAuthorization implements AuthorizeInterface
 	protected $error;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Authorization\GroupModel
 	 */
 	protected $groupModel;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Authorization\PermissionModel
 	 */
 	protected $permissionModel;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Models\UserModel
 	 */
 	protected $userModel = null;
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -207,7 +207,7 @@ class AuthController extends Controller
 	 */
 	public function forgotPassword()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -221,7 +221,7 @@ class AuthController extends Controller
 	 */
 	public function attemptForgot()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -255,7 +255,7 @@ class AuthController extends Controller
 	 */
 	public function resetPassword()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -276,7 +276,7 @@ class AuthController extends Controller
 	 */
 	public function attemptReset()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}


### PR DESCRIPTION
There seems to be some confusion about the config's `activeSetter` type for the disabled state. For now I am loosening the dependent code to accept either `false` (current code assumption) or `''` (config property type hint).

This is part of a larger fix to the Resetters issue.