### PR TITLE
Tighten Resetter Classes

### DIFF
--- a/src/Authentication/Resetters/BaseResetter.php
+++ b/src/Authentication/Resetters/BaseResetter.php
@@ -1,31 +1,70 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
-class BaseResetter
+use Myth\Auth\Config\Auth;
+use Myth\Auth\Entities\User;
+
+abstract class BaseResetter
 {
-    protected $config;
+	/**
+	 * @var Auth
+	 */
+	protected $config;
 
-    /**
-     * Allows for setting a config file on the Resetter.
-     *
-     * @param $config
-     *
-     * @return $this
-     */
-    public function setConfig($config)
-    {
-        $this->config = $config;
+	/**
+	 * @var string
+	 */
+	protected $error = '';
 
-        return $this;
-    }
+	/**
+	 * Sends a reset message to user
+	 *
+	 * @param User $user
+	 *
+	 * @return bool
+	 */
+	abstract public function send(User $user = null): bool;
 
-    /**
-     * Gets a config settings for current Resetter.
-     *
-     * @return $array
-     */
-    public function getResetterSettings()
-    {
-        return (object) $this->config->userResetters[get_class($this)];
-    }
+	/**
+	 * Sets the initial config file.
+	 *
+	 * @param Auth|null $config
+	 */
+	public function __construct(Auth $config = null)
+	{
+		$this->config = $config ?? config('Auth');
+	}
 
+	/**
+	 * Allows for changing the config file on the Resetter.
+	 *
+	 * @param Auth $config
+	 *
+	 * @return $this
+	 */
+	public function setConfig(Auth $config)
+	{
+		$this->config = $config;
+
+		return $this;
+	}
+
+	/**
+	 * Gets a config settings for current Resetter.
+	 *
+	 * @return object
+	 */
+	public function getResetterSettings()
+	{
+		return (object) $this->config->userResetters[static::class];
+	}
+
+	/**
+	 * Returns the current error.
+	 *
+	 * @return string
+	 */
+	public function error(): string
+	{
+		return $this->error;
+	}
 }

--- a/src/Authentication/Resetters/EmailResetter.php
+++ b/src/Authentication/Resetters/EmailResetter.php
@@ -1,8 +1,8 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
 use Config\Email;
-use CodeIgniter\Entity;
 use CodeIgniter\Config\Services;
+use Myth\Auth\Entities\User;
 
 /**
  * Class EmailResetter
@@ -14,18 +14,13 @@ use CodeIgniter\Config\Services;
 class EmailResetter extends BaseResetter implements ResetterInterface
 {
     /**
-     * @var string
-     */
-    protected $error;
-
-    /**
      * Sends a reset email
      *
      * @param User $user
      *
-     * @return mixed
+     * @return bool
      */
-    public function send(Entity $user = null): bool
+    public function send(User $user = null): bool
     {
         $email = Services::email();
         $config = new Email();
@@ -47,15 +42,4 @@ class EmailResetter extends BaseResetter implements ResetterInterface
 
         return true;
     }
-
-    /**
-     * Returns the error string that should be displayed to the user.
-     *
-     * @return string
-     */
-    public function error(): string
-    {
-        return $this->error ?? '';
-    }
-
 }

--- a/src/Authentication/Resetters/ResetterInterface.php
+++ b/src/Authentication/Resetters/ResetterInterface.php
@@ -1,7 +1,7 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
 use CodeIgniter\Entity;
-
+use Myth\Auth\Entities\User;
 /**
  * Interface ResetterInterface
  *
@@ -14,9 +14,9 @@ interface ResetterInterface
      *
      * @param User $user
      *
-     * @return mixed
+     * @return bool
      */
-    public function send(Entity $user = null): bool;
+    public function send(User $user = null): bool;
 
     /**
      * Returns the error string that should be displayed to the user.
@@ -24,5 +24,4 @@ interface ResetterInterface
      * @return string
      */
     public function error(): string;
-
 }

--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -27,7 +27,7 @@ class UserResetter
      */
     public function send(User $user = null): bool
     {
-        if ($this->config->activeResetter === false)
+        if (! $this->config->activeResetter)
         {
             return true;
         }

--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -3,59 +3,36 @@
 use Myth\Auth\Config\Auth;
 use Myth\Auth\Entities\User;
 
-class UserResetter
+class UserResetter extends BaseResetter implements ResetterInterface
 {
-    /**
-     * @var Auth
-     */
-    protected $config;
+	/**
+	 * Sends reset message to the user via specified class
+	 * in `$activeResetter` setting in Config\Auth.php.
+	 *
+	 * @param User $user
+	 *
+	 * @return bool
+	 */
+	public function send(User $user = null): bool
+	{
+		if (! $this->config->activeResetter)
+		{
+			return true;
+		}
 
-    protected $error;
+		$className = $this->config->activeResetter;
 
-    public function __construct(Auth $config)
-    {
-        $this->config = $config;
-    }
+		$class = new $className();
+		$class->setConfig($this->config);
 
-    /**
-     * Sends reset message to the user via specified class
-     * in `$activeResetter` setting in Config\Auth.php.
-     *
-     * @param User $user
-     *
-     * @return bool
-     */
-    public function send(User $user = null): bool
-    {
-        if (! $this->config->activeResetter)
-        {
-            return true;
-        }
+		if ($class->send($user) === false)
+		{
+			log_message('error', lang('Auth.errorResetting', [$user->username]));
+			$this->error = $class->error();
 
-        $className = $this->config->activeResetter;
+			return false;
+		}
 
-        $class = new $className();
-        $class->setConfig($this->config);
-
-        if ($class->send($user) === false)
-        {
-            log_message('error', "Failed to send reset messaage to: {$user->email}");
-            $this->error = $class->error();
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Returns the current error.
-     *
-     * @return mixed
-     */
-    public function error()
-    {
-        return $this->error;
-    }
-
+		return true;
+	}
 }

--- a/src/Authorization/FlatAuthorization.php
+++ b/src/Authorization/FlatAuthorization.php
@@ -12,17 +12,29 @@ class FlatAuthorization implements AuthorizeInterface
 	protected $error;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Authorization\GroupModel
 	 */
 	protected $groupModel;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Authorization\PermissionModel
 	 */
 	protected $permissionModel;
 
 	/**
-	 * @var Model
+	 * The group model to use. Usually the class noted
+	 * below (or an extension thereof) but can be any
+	 * compatible CodeIgniter Model.
+	 *
+	 * @var Myth\Auth\Models\UserModel
 	 */
 	protected $userModel = null;
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -207,7 +207,7 @@ class AuthController extends Controller
 	 */
 	public function forgotPassword()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -221,7 +221,7 @@ class AuthController extends Controller
 	 */
 	public function attemptForgot()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -255,7 +255,7 @@ class AuthController extends Controller
 	 */
 	public function resetPassword()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -276,7 +276,7 @@ class AuthController extends Controller
 	 */
 	public function attemptReset()
 	{
-		if ($this->config->activeResetter === false)
+		if (! $this->config->activeResetter)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -31,12 +31,13 @@ return [
     'invalidPassword'           => 'Unable to log you in. Please check your password.',
 
     // Forgotten Passwords
-    'forgotDisabled'            => 'Resseting password option has been disabled.',
+    'forgotDisabled'            => 'Reseting password option has been disabled.',
     'forgotNoUser'              => 'Unable to locate a user with that email.',
     'forgotSubject'             => 'Password Reset Instructions',
     'resetSuccess'              => 'Your password has been successfully changed. Please login with the new password.',
     'forgotEmailSent'           => 'A security token has been emailed to you. Enter it in the box below to continue.',
     'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}',
+    'errorResetting'            => 'Unable to send reset instructions to {0}',
 
     // Passwords
     'errorPasswordLength'       => 'Passwords must be at least {0, number} characters long.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -31,12 +31,13 @@ return [
     'invalidPassword'           => 'No se pudo ingresar al sistema. Por favor, chequee sus credenciales.',
 
     // Forgotten Passwords
-    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
+    'forgotDisabled'            => 'Reseting password option has been disabled.', // translate
     'forgotNoUser'              => 'No se pudo localizar un usuario con ese correo electrónico.',
     'forgotSubject'             => 'Instrucciones para resetear la contraseña',
     'resetSuccess'              => 'El cambio de contraseña fue correcto. Por favor ingrese con su nueva contraseña.',
     'forgotEmailSent'           => 'Se ha enviado un código de seguridad a su e-mail. Ingréselo en el cuadro siguiente para continuar.',
     'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
+    'errorResetting'            => 'Unable to send reset instructions to {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'La contraseña debe tener al menos {0, number} caracteres.',

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -36,7 +36,8 @@ return [
     'forgotSubject'             => 'Instructions de réinitialisation de mot de passe',
     'resetSuccess'              => 'Votre mot de passe a été changé avec succès. Veuillez vous connecter avec le nouveau mot de passe.',
     'forgotEmailSent'           => 'Un jeton d’authentification vous a été envoyée par e-mail. Saisissez le dans le champ ci-dessous pour continuer.',
-    'errorEmailSent'            => 'Échec lors de l’envoi de l’e-mail d’instructions de réinitialisation de mot de passe à : {0}',
+    'errorEmailSent'            => 'Échec lors de l’envoi de l’e-mail d’instructions de réinitialisation de mot de passe à: {0}',
+    'errorResetting'            => 'Échec lors de l’envoi d’instructions de réinitialisation de mot de passe à: {0}',
 
     // Passwords
     'errorPasswordLength'       => 'Les mots de passe doivent contenir au moins {0, number} caractères.',

--- a/src/Language/it/Auth.php
+++ b/src/Language/it/Auth.php
@@ -36,7 +36,8 @@ return [
     'forgotSubject'             => 'Istruzioni per il Ripristino della Password',
     'resetSuccess'              => 'La tua password è stata cambiata con successo. Effettua l\'accesso con le tue nuove credenziali.',
     'forgotEmailSent'           => 'Un token di sicurezza è stato inviato al tuo indirizzo email. Inseriscilo nella casella qui sotto per continuare.',
-    'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
+    'errorEmailSent'            => 'Impossibile inviare l\'email con le istruzioni per resettare la password all\'indirizzo: {0}',
+    'errorResetting'            => 'Impossibile inviare le istruzioni per resettare la password a: {0}',
 
     // Passwords
     'errorPasswordLength'       => 'La password deve contenere almeno {0, number} caratteri.',

--- a/src/Language/pt-BR/Auth.php
+++ b/src/Language/pt-BR/Auth.php
@@ -30,12 +30,13 @@ return [
     'loginSuccess'              => 'Bem-vindo de volta!',
 
     // Forgotten Passwords
-    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
+    'forgotDisabled'            => 'Reseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Não foi possível localizar um  usuário com esse e-mail.',
     'forgotSubject'             => 'Instruções de redefinição de senha',
     'resetSuccess'              => 'Sua senha foi alterada com sucesso. Por favor, entre com sua nova senha.',
     'forgotEmailSent'           => 'Um token de segurança foi enviado para o seu e-mail. Cole-o no campo abaixo para continuar.',
     'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
+    'errorResetting'            => 'Unable to send reset instructions to {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'A senha deve conter pelo menos {0, number} caracteres.',

--- a/src/Language/ru/Auth.php
+++ b/src/Language/ru/Auth.php
@@ -29,12 +29,13 @@ return [
     'loginSuccess'              => 'С возвращением!',
 
     // Forgotten Passwords
-    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
+    'forgotDisabled'            => 'Reseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Не удалось найти пользователя с этим email.',
     'forgotSubject'             => 'Восстановление пароля',
     'resetSuccess'              => 'Ваш пароль был успешно изменен. Пожалуйста, войдите, используя новый пароль.',
     'forgotEmailSent'           => 'Токен безопасности был отправлен на ваш email. Введите его в поле ниже.',
     'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
+    'errorResetting'            => 'Unable to send reset instructions to {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'Длина пароля должна быть не менее {0, number} символов(а).',

--- a/src/Language/tr/Auth.php
+++ b/src/Language/tr/Auth.php
@@ -31,12 +31,13 @@ return [
     'invalidPassword'           => 'Giriş yapılamıyor. Lütfen bilgilerinizi kontrol edin.',
 
     // Forgotten Passwords
-    'forgotDisabled'            => 'Resseting password option has been disabled.', // translate
+    'forgotDisabled'            => 'Reseting password option has been disabled.', // translate
     'forgotNoUser'              => 'Bu emaile sahip bir kullanıcı bulunamıyor.',
     'forgotSubject'             => 'Parola Sıfırlama Adımları',
     'resetSuccess'              => 'Parolanız başarıyla değiştirildi. Yeni parolanızla giriş yapabilirsiniz.',
     'forgotEmailSent'           => 'Email adresinize bir güvenlik kodu gönderildi. Devam etmek için bu kodu aşağıdaki alana girin.',
     'errorEmailSent'            => 'Unable to send email with password reset instructions to: {0}', // translate
+    'errorResetting'            => 'Unable to send reset instructions to {0}', // translate
 
     // Passwords
     'errorPasswordLength'       => 'Parola en az {0, number} karakter uzunluğunda olmalıdır.',


### PR DESCRIPTION
There are some internal inconsistencies among the Resetter base, interface, and classes. This moves everything to `BaseResetter` and makes it `abstract`, while still leaving the interface for now. `UserResetter` is now also a proper resetter, even though it is a "proxy" of sorts, which saves on duplicate methods.

Note: requires #304