### PR TITLE
Add Composer provision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
 			"Tests\\Support\\": "tests/_support"
 		}
 	},
+	"provide": {
+		"codeigniter4/authentication-implementation": "1.0"
+	},
 	"scripts": {
 		"analyze": "phpstan analyze",
 		"style": "phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 src/ tests/",


### PR DESCRIPTION
Allows Myth:Auth to provide a CodeIgniter 4 authentication implementation. See https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html