### PR TITLE
Added ‘IF NOT EXISTS’ value to tables

### DIFF
--- a/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
@@ -78,7 +78,7 @@ class CreateAuthTables extends Migration
             'created_at' => ['type' => 'datetime', 'null' => false],
         ]);
         $this->forge->addKey('id', true);
-        $this->forge->createTable('auth_reset_attempts');
+        $this->forge->createTable('auth_reset_attempts', true);
 
         /*
          * Activation Attempts Table
@@ -91,7 +91,7 @@ class CreateAuthTables extends Migration
             'created_at' => ['type' => 'datetime', 'null' => false],
         ]);
         $this->forge->addKey('id', true);
-        $this->forge->createTable('auth_activation_attempts');
+        $this->forge->createTable('auth_activation_attempts', true);
 
         /*
          * Groups Table
@@ -159,7 +159,7 @@ class CreateAuthTables extends Migration
         $this->forge->addKey(['user_id', 'permission_id']);
         $this->forge->addForeignKey('user_id', 'users', 'id', false, 'CASCADE');
         $this->forge->addForeignKey('permission_id', 'auth_permissions', 'id', false, 'CASCADE');
-        $this->forge->createTable('auth_users_permissions');
+        $this->forge->createTable('auth_users_permissions', true);
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
Added true value to `createTable()` for `table auth_reset_attempts`, `auth_activation_attempts` and `auth_users_permissions`.

Resolves #337.