### PR TITLE
Conditional Workflow Authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
           tools: composer, pecl, phpunit
           extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,15 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install dependencies
+      - name: Install dependencies (limited)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Install dependencies (authenticated)
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        env:
+          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Test with PHPUnit
         run: vendor/bin/phpunit --verbose --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"fakerphp/faker": "^1.9",
 		"mockery/mockery": "^1.0",
 		"phpstan/phpstan": "^0.12",
-		"phpunit/phpunit": "^9.1",
+		"phpunit/phpunit": "^9.2",
 		"squizlabs/php_codesniffer": "^3.5"
 	},
 	"autoload": {


### PR DESCRIPTION
This is what I finally settled on for my libraries. It duplicates the Composer installation step and makes them conditional, basically: "only use the secret during Composer updates when it is not a fork pull request".