### PR TITLE
fix(types): update wrong types in AuthConfig + declarations

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -204,7 +204,7 @@ account by accessing `AuthController->register()`. NOTE: This setting is not enf
 or edit controller and views you are responsible for checking this value.
 
 ### auth.requireActivation
-This can be either false or string with a namespaced class name. Using a class name will force `activator` service to use this
+This can be either null or string with a namespaced class name. Using a class name will force `activator` service to use this
 class to send an activation message.
 
 	public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
@@ -221,7 +221,7 @@ by `requireActivation` config variable.
     ];
 
 ### auth.activeResetter
-This can be either false or string with a namespaced class name. Using a class name will force `resetter` service to use this
+This can be either null or string with a namespaced class name. Using a class name will force `resetter` service to use this
  class to send a reset message.
 
 	public $activeResetter = 'Myth\Auth\Authentication\Resetters\EmailResetter';

--- a/src/Authentication/Activators/ActivatorInterface.php
+++ b/src/Authentication/Activators/ActivatorInterface.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Authentication\Activators;
 
-use CodeIgniter\Entity;
 use Myth\Auth\Entities\User;
 
 /**

--- a/src/Authentication/Activators/BaseActivator.php
+++ b/src/Authentication/Activators/BaseActivator.php
@@ -1,12 +1,12 @@
 <?php namespace Myth\Auth\Authentication\Activators;
 
-use Myth\Auth\Config\Auth;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Entities\User;
 
 abstract class BaseActivator
 {
 	/**
-	 * @var Auth
+	 * @var AuthConfig
 	 */
 	protected $config;
 
@@ -27,9 +27,9 @@ abstract class BaseActivator
 	/**
 	 * Sets the initial config file.
 	 *
-	 * @param Auth|null $config
+	 * @param AuthConfig|null $config
 	 */
-	public function __construct(Auth $config = null)
+	public function __construct(AuthConfig $config = null)
 	{
 		$this->config = $config ?? config('Auth');
 	}

--- a/src/Authentication/Activators/UserActivator.php
+++ b/src/Authentication/Activators/UserActivator.php
@@ -19,7 +19,7 @@ class UserActivator extends BaseActivator implements ActivatorInterface
 			return true;
 		}
 
-		$className = $this->config->activeResetter;
+		$className = $this->config->requireActivation;
 
 		$class = new $className();
 		$class->setConfig($this->config);

--- a/src/Authentication/Activators/UserActivator.php
+++ b/src/Authentication/Activators/UserActivator.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Authentication\Activators;
 
-use Myth\Auth\Config\Auth;
 use Myth\Auth\Entities\User;
 
 class UserActivator extends BaseActivator implements ActivatorInterface

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -1,8 +1,8 @@
 <?php namespace Myth\Auth\Authentication;
 
-use Config\App;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Model;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Exceptions\AuthException;
 use Myth\Auth\Exceptions\UserNotFoundException;
@@ -31,7 +31,7 @@ class AuthenticationBase
     protected $error;
 
     /**
-     * @var \Config\Auth
+     * @var AuthConfig
      */
     protected $config;
 
@@ -67,7 +67,7 @@ class AuthenticationBase
      * NOTE: does not perform validation. All validation should
      * be done prior to using the login method.
      *
-     * @param \Myth\Auth\Entities\User $user
+     * @param User $user
      * @param bool                     $remember
      *
      * @return bool
@@ -314,7 +314,7 @@ class AuthenticationBase
     /**
      * Returns the User instance for the current logged in user.
      *
-     * @return \Myth\Auth\Entities\User|null
+     * @return User|null
      */
     public function user()
     {
@@ -351,7 +351,7 @@ class AuthenticationBase
      * Sets the model that should be used to work with
      * user accounts.
      *
-     * @param \CodeIgniter\Model $model
+     * @param Model $model
      *
      * @return $this
      */

--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -35,7 +35,7 @@ interface AuthenticatorInterface
     /**
      * Returns the User instance for the current logged in user.
      *
-     * @return \Myth\Auth\Entities\User|null
+     * @return User|null
      */
     public function user();
 }

--- a/src/Authentication/Passwords/NothingPersonalValidator.php
+++ b/src/Authentication/Passwords/NothingPersonalValidator.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Authentication\Passwords;
 
 use CodeIgniter\Entity;
-use Myth\Auth\Exceptions\AuthException;
 
 /**
  * Class NothingPersonalValidator

--- a/src/Authentication/Passwords/PasswordValidator.php
+++ b/src/Authentication/Passwords/PasswordValidator.php
@@ -1,13 +1,13 @@
 <?php namespace Myth\Auth\Authentication\Passwords;
 
-use Myth\Auth\Config\Auth;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Exceptions\AuthException;
 
 class PasswordValidator
 {
 	/**
-	 * @var Auth
+	 * @var AuthConfig
 	 */
 	protected $config;
 
@@ -15,7 +15,7 @@ class PasswordValidator
 
 	protected $suggestion;
 
-	public function __construct(Auth $config)
+	public function __construct(AuthConfig $config)
 	{
 		$this->config = $config;
 	}

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Authentication\Passwords;
 
-use Config\Services;
 use Myth\Auth\Entities\User;
 
 /**
@@ -63,7 +62,7 @@ class ValidationRules
     /**
      * Builds a new user instance from the global request.
      *
-     * @return \Myth\Auth\Entities\User
+     * @return User
      */
     protected function buildUserFromRequest()
     {
@@ -79,7 +78,7 @@ class ValidationRules
      *
      * @param array $data Assigned data
      *
-     * @return \Myth\Auth\Entities\User
+     * @return User
      */
     protected function buildUserFromData(array $data = [])
     {

--- a/src/Authentication/Resetters/BaseResetter.php
+++ b/src/Authentication/Resetters/BaseResetter.php
@@ -1,12 +1,12 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
-use Myth\Auth\Config\Auth;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Entities\User;
 
 abstract class BaseResetter
 {
 	/**
-	 * @var Auth
+	 * @var AuthConfig
 	 */
 	protected $config;
 
@@ -27,9 +27,9 @@ abstract class BaseResetter
 	/**
 	 * Sets the initial config file.
 	 *
-	 * @param Auth|null $config
+	 * @param AuthConfig|null $config
 	 */
-	public function __construct(Auth $config = null)
+	public function __construct(AuthConfig $config = null)
 	{
 		$this->config = $config ?? config('Auth');
 	}
@@ -37,11 +37,11 @@ abstract class BaseResetter
 	/**
 	 * Allows for changing the config file on the Resetter.
 	 *
-	 * @param Auth $config
+	 * @param AuthConfig $config
 	 *
 	 * @return $this
 	 */
-	public function setConfig(Auth $config)
+	public function setConfig(AuthConfig $config)
 	{
 		$this->config = $config;
 

--- a/src/Authentication/Resetters/ResetterInterface.php
+++ b/src/Authentication/Resetters/ResetterInterface.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
-use CodeIgniter\Entity;
 use Myth\Auth\Entities\User;
 /**
  * Interface ResetterInterface

--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -14,7 +14,7 @@ class UserResetter extends BaseResetter implements ResetterInterface
 	 */
 	public function send(User $user = null): bool
 	{
-		if (! $this->config->activeResetter)
+		if ($this->config->activeResetter === null)
 		{
 			return true;
 		}

--- a/src/Authentication/Resetters/UserResetter.php
+++ b/src/Authentication/Resetters/UserResetter.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
-use Myth\Auth\Config\Auth;
 use Myth\Auth\Entities\User;
 
 class UserResetter extends BaseResetter implements ResetterInterface

--- a/src/Authorization/PermissionModel.php
+++ b/src/Authorization/PermissionModel.php
@@ -1,6 +1,8 @@
 <?php namespace Myth\Auth\Authorization;
 
 use CodeIgniter\Model;
+use BaseResult;
+use Query;
 
 class PermissionModel extends Model
 {
@@ -52,7 +54,7 @@ class PermissionModel extends Model
      * @param int $permissionId
      * @param int $userId
      *
-     * @return \CodeIgniter\Database\BaseResult|\CodeIgniter\Database\Query|false
+     * @return BaseResult|Query|false
      */
     public function addPermissionToUser(int $permissionId, int $userId)
     {

--- a/src/Commands/CreateUser.php
+++ b/src/Commands/CreateUser.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Config\Services;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -145,7 +145,7 @@ class Auth extends BaseConfig
 	 * When enabled, every registered user will receive an email message
 	 * with an activation link to confirm the account.
 	 *
-	 * @var string Name of the ActivatorInterface class
+	 * @var string|false Name of the ActivatorInterface class
 	 */
 	public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
 
@@ -157,7 +157,7 @@ class Auth extends BaseConfig
 	 * When enabled, users will have the option to reset their password
 	 * via the specified Resetter. Default setting is email.
 	 *
-	 * @var string Name of the ResetterInterface class
+	 * @var string|false Name of the ResetterInterface class
 	 */
 	public $activeResetter = 'Myth\Auth\Authentication\Resetters\EmailResetter';
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -145,7 +145,7 @@ class Auth extends BaseConfig
 	 * When enabled, every registered user will receive an email message
 	 * with an activation link to confirm the account.
 	 *
-	 * @var string|false Name of the ActivatorInterface class
+	 * @var string|null Name of the ActivatorInterface class
 	 */
 	public $requireActivation = 'Myth\Auth\Authentication\Activators\EmailActivator';
 
@@ -157,7 +157,7 @@ class Auth extends BaseConfig
 	 * When enabled, users will have the option to reset their password
 	 * via the specified Resetter. Default setting is email.
 	 *
-	 * @var string|false Name of the ResetterInterface class
+	 * @var string|null Name of the ResetterInterface class
 	 */
 	public $activeResetter = 'Myth\Auth\Authentication\Resetters\EmailResetter';
 

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -1,7 +1,7 @@
 <?php namespace Myth\Auth\Config;
 
 use CodeIgniter\Model;
-use Config\Auth as AuthConfig;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Authorization\FlatAuthorization;
 use Myth\Auth\Models\UserModel;
 use Myth\Auth\Models\LoginModel;
@@ -55,38 +55,38 @@ class Services extends BaseService
 	/**
 	 * Returns an instance of the PasswordValidator.
 	 *
-	 * @param Auth|null $config
+	 * @param AuthConfig|null $config
 	 * @param bool      $getShared
 	 *
 	 * @return ValidatorInterface
 	 */
-	public static function passwords(Auth $config = null, bool $getShared = true): PasswordValidator
+	public static function passwords(AuthConfig $config = null, bool $getShared = true): PasswordValidator
 	{
 		if ($getShared)
 		{
 			return self::getSharedInstance('passwords', $config);
 		}
 
-		return new PasswordValidator($config ?? config(Auth::class));
+		return new PasswordValidator($config ?? config(AuthConfig::class));
 	}
 
 	/**
 	 * Returns an instance of the Activator.
 	 *
-	 * @param Auth|null $config
+	 * @param AuthConfig|null $config
 	 * @param bool      $getShared
 	 *
 	 * @return ActivatorInterface
 	 */
-	public static function activator(Auth $config = null, bool $getShared = true): ActivatorInterface
+	public static function activator(AuthConfig $config = null, bool $getShared = true): ActivatorInterface
 	{
 		if ($getShared)
 		{
 			return self::getSharedInstance('activator', $config);
 		}
 
-		$config = $config ?? config(Auth::class);
-		$class	= $config->requireActivation ?: UserActivator::class;
+		$config = $config ?? config(AuthConfig::class);
+		$class	= $config->requireActivation ?? UserActivator::class;
 
 		return new $class($config);
 	}
@@ -94,20 +94,20 @@ class Services extends BaseService
 	/**
 	 * Returns an instance of the Resetter.
 	 *
-	 * @param Auth|null $config
+	 * @param AuthConfig|null $config
 	 * @param bool      $getShared
 	 *
 	 * @return ResetterInterface
 	 */
-	public static function resetter(Auth $config = null, bool $getShared = true): ResetterInterface
+	public static function resetter(AuthConfig $config = null, bool $getShared = true): ResetterInterface
 	{
 		if ($getShared)
 		{
 			return self::getSharedInstance('resetter', $config);
 		}
 
-		$config = $config ?? config(Auth::class);
-		$class	= $config->activeResetter ?: EmailResetter::class;
+		$config = $config ?? config(AuthConfig::class);
+		$class	= $config->activeResetter ?? EmailResetter::class;
 
 		return new $class($config);
 	}

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -1,6 +1,7 @@
 <?php namespace Myth\Auth\Config;
 
 use CodeIgniter\Model;
+use Config\Auth as AuthConfig;
 use Myth\Auth\Authorization\FlatAuthorization;
 use Myth\Auth\Models\UserModel;
 use Myth\Auth\Models\LoginModel;
@@ -25,7 +26,7 @@ class Services extends BaseService
 		$userModel  = $userModel ?? model(UserModel::class);
 		$loginModel = $loginModel ?? model(LoginModel::class);
 
-		/** @var \Myth\Auth\Config\Auth $config */
+		/** @var AuthConfig $config */
 		$config   = config('Auth');
 		$class	  = $config->authenticationLibs[$lib];
 		$instance = new $class($config);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -170,7 +170,7 @@ class AuthController extends Controller
 		$allowedPostFields = array_merge(['password'], $this->config->validFields, $this->config->personalFields);
 		$user = new User($this->request->getPost($allowedPostFields));
 
-		$this->config->requireActivation !== false ? $user->generateActivateHash() : $user->activate();
+		$this->config->requireActivation === null ? $user->activate : $user->generateActivateHash();
 
 		// Ensure default group gets assigned if set
         if (! empty($this->config->defaultUserGroup)) {
@@ -182,7 +182,7 @@ class AuthController extends Controller
 			return redirect()->back()->withInput()->with('errors', $users->errors());
 		}
 
-		if ($this->config->requireActivation !== false)
+		if ($this->config->requireActivation !== null)
 		{
 			$activator = service('activator');
 			$sent = $activator->send($user);
@@ -209,7 +209,7 @@ class AuthController extends Controller
 	 */
 	public function forgotPassword()
 	{
-		if (! $this->config->activeResetter)
+		if ($this->config->activeResetter === null)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -223,7 +223,7 @@ class AuthController extends Controller
 	 */
 	public function attemptForgot()
 	{
-		if (! $this->config->activeResetter)
+		if ($this->config->activeResetter === null)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -257,7 +257,7 @@ class AuthController extends Controller
 	 */
 	public function resetPassword()
 	{
-		if (! $this->config->activeResetter)
+		if ($this->config->activeResetter === null)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -278,7 +278,7 @@ class AuthController extends Controller
 	 */
 	public function attemptReset()
 	{
-		if (! $this->config->activeResetter)
+		if ($this->config->activeResetter === null)
 		{
 			return redirect()->route('login')->with('error', lang('Auth.forgotDisabled'));
 		}
@@ -377,7 +377,7 @@ class AuthController extends Controller
 	 */
 	public function resendActivateAccount()
 	{
-		if ($this->config->requireActivation === false)
+		if ($this->config->requireActivation === null)
 		{
 			return redirect()->route('login');
 		}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -1,20 +1,22 @@
 <?php namespace Myth\Auth\Controllers;
 
-use Config\Email;
 use CodeIgniter\Controller;
+use CodeIgniter\Session\Session;
+use Myth\Auth\Config\Auth as AuthConfig;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
 
 class AuthController extends Controller
 {
 	protected $auth;
+
 	/**
-	 * @var Auth
+	 * @var AuthConfig
 	 */
 	protected $config;
 
 	/**
-	 * @var \CodeIgniter\Session\Session
+	 * @var Session
 	 */
 	protected $session;
 

--- a/src/Filters/LoginFilter.php
+++ b/src/Filters/LoginFilter.php
@@ -16,7 +16,7 @@ class LoginFilter implements FilterInterface
 	 * sent back to the client, allowing for error pages,
 	 * redirects, etc.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param RequestInterface $request
 	 * @param array|null                         $params
 	 *
 	 * @return mixed
@@ -63,8 +63,8 @@ class LoginFilter implements FilterInterface
 	 * to stop execution of other after filters, short of
 	 * throwing an Exception or Error.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface  $request
-	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param RequestInterface  $request
+	 * @param ResponseInterface $response
 	 * @param array|null                          $arguments
 	 *
 	 * @return void

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -17,7 +17,7 @@ class PermissionFilter implements FilterInterface
 	 * sent back to the client, allowing for error pages,
 	 * redirects, etc.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param RequestInterface $request
 	 * @param array|null                         $params
 	 *
 	 * @return mixed
@@ -74,8 +74,8 @@ class PermissionFilter implements FilterInterface
 	 * to stop execution of other after filters, short of
 	 * throwing an Exception or Error.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface  $request
-	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param RequestInterface  $request
+	 * @param ResponseInterface $response
 	 * @param array|null                          $arguments
 	 *
 	 * @return void

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -17,7 +17,7 @@ class RoleFilter implements FilterInterface
 	 * sent back to the client, allowing for error pages,
 	 * redirects, etc.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param RequestInterface $request
 	 * @param array|null                         $params
 	 *
 	 * @return mixed
@@ -73,8 +73,8 @@ class RoleFilter implements FilterInterface
 	 * to stop execution of other after filters, short of
 	 * throwing an Exception or Error.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface  $request
-	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param RequestInterface  $request
+	 * @param ResponseInterface $response
 	 * @param array|null                          $arguments
 	 *
 	 * @return void

--- a/src/Helpers/auth_helper.php
+++ b/src/Helpers/auth_helper.php
@@ -1,5 +1,6 @@
 <?php
 
+use Myth\Auth\Entities\User;
 
 if (! function_exists('logged_in'))
 {
@@ -19,7 +20,7 @@ if (! function_exists('user'))
 	/**
 	 * Returns the User instance for the current logged in user.
 	 *
-	 * @return \Myth\Auth\Entities\User|null
+	 * @return User|null
 	 */
 	function user()
 	{

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Myth\Auth\Entities\User;
 use Tests\Support\AuthTestCase;
 
 class UserTest extends AuthTestCase

--- a/tests/_support/AuthTestCase.php
+++ b/tests/_support/AuthTestCase.php
@@ -1,15 +1,11 @@
 <?php namespace Tests\Support;
 
-use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
-use CodeIgniter\Test\Mock\MockSession;
-use Config\Services;
 use Faker\Factory;
 use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
-use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
 use Myth\Auth\Test\AuthTestTrait;
 use Myth\Auth\Test\Fakers\GroupFaker;

--- a/tests/authentication/LocalAuthTest.php
+++ b/tests/authentication/LocalAuthTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Myth\Auth\Entities\User;
 use Myth\Auth\Models\UserModel;
 use Myth\Auth\Authentication\LocalAuthenticator;
 use Tests\Support\AuthTestCase;

--- a/tests/controllers/RegisterTest.php
+++ b/tests/controllers/RegisterTest.php
@@ -89,7 +89,7 @@ class RegisterTest extends AuthTestCase
 
         // don't require activation for this...
         $config = config('Auth');
-        $config->requireActivation = false;
+        $config->requireActivation = null;
         \CodeIgniter\Config\Config::injectMock('Auth', $config);
 
         $result = $this->withUri(site_url('register'))
@@ -127,7 +127,7 @@ class RegisterTest extends AuthTestCase
 
         // don't require activation for this...
         $config = config('Auth');
-        $config->requireActivation = false;
+        $config->requireActivation = null;
         $config->defaultUserGroup = $group->name;
         \CodeIgniter\Config\Config::injectMock('Auth', $config);
 

--- a/tests/unit/AuthTestTraitTest.php
+++ b/tests/unit/AuthTestTraitTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Myth\Auth\Test\Fakers\PermissionFaker;
 use Myth\Auth\Test\Fakers\UserFaker;
 use Tests\Support\AuthTestCase;
 

--- a/tests/unit/UserModelTest.php
+++ b/tests/unit/UserModelTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Myth\Auth\Models\UserModel;
-use Myth\Auth\Authorization\GroupModel;
 use Tests\Support\AuthTestCase;
 
 class UserModelTest extends AuthTestCase


### PR DESCRIPTION
This is a follow up on my previous PR (https://github.com/lonnieezell/myth-auth/pull/347). I apparently haven't checked everything and found other issues regarding types, especially in the Auth config file.
I took the opportunity to remove all unused class declarations and make them a bit more consistent (correcting a few wrongly typed declarations along the way).

To prevent this from happening again, I guess it would be better reactivating static analysis in the github actions workflow?