### PR TITLE
refactor: replace `Config\Services` with service helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ The following Services are provided by the package:
 Provides access to any of the authentication packages that Myth:Auth knows about. By default
 it will return the "Local Authentication" library, which is the basic password-based system.
 
-    $authenticate = Config\Services::authentication();
+    $authenticate = service('authentication');
     
 You can specify the library to use as the first argument:
 
-    $authenticate = Config\Services::authentication('jwt');
+    $authenticate = service('authentication', 'jwt');
     
 **authorization**
 
@@ -125,7 +125,7 @@ Provides access to any of the authorization libraries that Myth:Auth knows about
 it will return the "Flat" authorization library, which is a Flat RBAC (role-based access control)
 as defined by NIST. It provides user-specific permissions as well as group (role) based permissions.
 
-    $authorize = Config\Services::authorization();
+    $authorize = service('authorization');
 
 **passwords**
 
@@ -134,7 +134,7 @@ supports many of [NIST's latest Digital Identity guidelines](https://pages.nist.
 validator comes with a dictionary of over 620,000 common/leaked passwords that can be checked against.
 A handful of variations on the user's email/username are automatically checked against. 
 
-    $authenticate = Config\Services::passwords();
+    $authenticate = service('passwords');
    
 Most of the time you should not need to access this library directly, though, as a new Validation rule
 is provided that can be used with the Validation library, `strong_password`. In order to enable this, 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -37,7 +37,7 @@ user against. The library does not enforce a specific set of credentials. You ar
 combination of fields that exist within the `users` table, but typical uses would be either `email` or `username`. 
 You must include a field name `password`, though as it will be verified against the hashed version in the database.
 
-	$auth = Services::authenticate();
+	$auth = service('authenticate');
 	
 	$credentials = [
 		'email' => $this->request->getPost('email', true),
@@ -158,7 +158,7 @@ This is done via `$requireActivation` config variable.
 Confirmation can be done in many ways. Traditionally, this is usually done by sending an email to the email address that was
 used during registration. We use the `Activator` service for this.
 
-	$activator = Services::activator();
+	$activator = service('activator');
 	$activator->send($user);
 
 By default, we provide one type of activator and this is `EmailActivator`. You can also prepare your own activator,

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -12,7 +12,7 @@ with users for low-level security. While the class can easily be used on it's ow
 You can get an instance of the authorization library using the provided Services class, which will automatically be 
 detected by CodeIgniter. 
 
-    $authorize = $auth = Config\Services::authorization();
+    $authorize = $auth = service('authorization');
     
 Once you have this service, you have full access to all of the methods described below.
 

--- a/src/AuthTrait.php
+++ b/src/AuthTrait.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth;
 
-use Config\Services;
 use CodeIgniter\Router\Exceptions\RedirectException;
 
 trait AuthTrait {
@@ -168,7 +167,7 @@ trait AuthTrait {
         /*
          * Authentication
          */
-        $this->authenticate = Services::authentication($this->authenticationLib);
+        $this->authenticate = service('authentication', $this->authenticationLib);
 
         // Try to log us in automatically.
         $this->authenticate->check();
@@ -176,7 +175,7 @@ trait AuthTrait {
         /*
          * Authorization
          */
-        $this->authorize = Services::authorization();
+        $this->authorize = service('authorization');
 
         $this->classesLoaded = true;
     }

--- a/src/Authentication/Activators/EmailActivator.php
+++ b/src/Authentication/Activators/EmailActivator.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Authentication\Activators;
 
 use Config\Email;
-use Config\Services;
 use Myth\Auth\Entities\User;
 
 /**
@@ -22,7 +21,7 @@ class EmailActivator extends BaseActivator implements ActivatorInterface
      */
     public function send(User $user = null): bool
     {
-        $email = Services::email();
+        $email = service('email');
         $config = new Email();
 
         $settings = $this->getActivatorSettings();

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -3,7 +3,6 @@
 use Config\App;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Model;
-use Config\Services;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Exceptions\AuthException;
 use Myth\Auth\Exceptions\UserNotFoundException;
@@ -85,7 +84,7 @@ class AuthenticationBase
         $this->user = $user;
 
         // Always record a login attempt
-        $ipAddress = Services::request()->getIPAddress();
+        $ipAddress = service('request')->getIPAddress();
         $this->recordLoginAttempt($user->email, $ipAddress, $user->id ?? null, true);
 
         // Regenerate the session ID to help protect against session fixation
@@ -98,7 +97,7 @@ class AuthenticationBase
         session()->set('logged_in', $this->user->id);
 
         // When logged in, ensure cache control headers are in place
-        Services::response()->noCache();
+        service('response')->noCache();
 
         if ($remember && $this->config->allowRemembering)
         {
@@ -244,7 +243,7 @@ class AuthenticationBase
 
         // Save it to the user's browser in a cookie.
         $appConfig = config('App');
-        $response = \Config\Services::response();
+        $response = service('response');
 
         // Create the cookie
         $response->setCookie(

--- a/src/Authentication/LocalAuthenticator.php
+++ b/src/Authentication/LocalAuthenticator.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Authentication;
 
 use CodeIgniter\Router\Exceptions\RedirectException;
-use \Config\Services;
 use Myth\Auth\Entities\User;
 use Myth\Auth\Exceptions\AuthException;
 
@@ -22,7 +21,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
         if (empty($this->user))
         {
             // Always record a login attempt, whether success or not.
-            $ipAddress = Services::request()->getIPAddress();
+            $ipAddress = service('request')->getIPAddress();
             $this->recordLoginAttempt($credentials['email'] ?? $credentials['username'], $ipAddress, $this->user->id ?? null, false);
 
             $this->user = null;
@@ -32,7 +31,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
         if ($this->user->isBanned())
         {
             // Always record a login attempt, whether success or not.
-            $ipAddress = Services::request()->getIPAddress();
+            $ipAddress = service('request')->getIPAddress();
             $this->recordLoginAttempt($credentials['email'] ?? $credentials['username'], $ipAddress, $this->user->id ?? null, false);
 
             $this->error = lang('Auth.userIsBanned');
@@ -44,7 +43,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
         if (! $this->user->isActivated())
         {
             // Always record a login attempt, whether success or not.
-            $ipAddress = Services::request()->getIPAddress();
+            $ipAddress = service('request')->getIPAddress();
             $this->recordLoginAttempt($credentials['email'] ?? $credentials['username'], $ipAddress, $this->user->id ?? null, false);
 
             $param = http_build_query([

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -3,7 +3,6 @@
 namespace Myth\Auth\Authentication\Passwords;
 
 use CodeIgniter\Entity;
-use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Myth\Auth\Exceptions\AuthException;
 
@@ -55,7 +54,7 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
 
         try
         {
-            $client = Services::curlrequest([
+            $client = service('curlrequest', [
                     'base_uri' => 'https://api.pwnedpasswords.com/',
             ]);
 
@@ -66,7 +65,7 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
         catch(HTTPException $e)
         {
             $exception = AuthException::forHIBPCurlFail($e);
-            Services::logger()->error('[ERROR] {exception}', ['exception' => $exception]);
+            service('logger')->error('[ERROR] {exception}', ['exception' => $exception]);
             throw $exception;
         }
 

--- a/src/Authentication/Resetters/EmailResetter.php
+++ b/src/Authentication/Resetters/EmailResetter.php
@@ -1,7 +1,6 @@
 <?php namespace Myth\Auth\Authentication\Resetters;
 
 use Config\Email;
-use CodeIgniter\Config\Services;
 use Myth\Auth\Entities\User;
 
 /**
@@ -22,7 +21,7 @@ class EmailResetter extends BaseResetter implements ResetterInterface
      */
     public function send(User $user = null): bool
     {
-        $email = Services::email();
+        $email = service('email');
         $config = new Email();
 
         $settings = $this->getResetterSettings();

--- a/src/Authorization/FlatAuthorization.php
+++ b/src/Authorization/FlatAuthorization.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\Model;
 use CodeIgniter\Events\Events;
-use Config\Services;
 use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
 use Myth\Auth\Models\UserModel;
@@ -485,7 +484,7 @@ class FlatAuthorization implements AuthorizeInterface
 			'description' => $description,
 		];
 
-		$validation = Services::validation(null, false);
+		$validation = service('validation', null, false);
 		$validation->setRules([
 			'name'		=> 'required|max_length[255]|is_unique[auth_groups.name]',
 			'description' => 'max_length[255]',
@@ -631,7 +630,7 @@ class FlatAuthorization implements AuthorizeInterface
 			'description' => $description,
 		];
 
-		$validation = Services::validation(null, false);
+		$validation = service('validation', null, false);
 		$validation->setRules([
 			'name'		=> 'required|max_length[255]|is_unique[auth_permissions.name]',
 			'description' => 'max_length[255]',

--- a/src/Commands/CreateGroup.php
+++ b/src/Commands/CreateGroup.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use Config\Services;
 
 class CreateGroup extends BaseCommand
 {
@@ -18,8 +17,7 @@ class CreateGroup extends BaseCommand
 
 	public function run(array $params = [])
     {
-		$db   = db_connect();
-		$auth = Services::authorization();
+		$auth = service('authorization');
 
 		// consume or prompt for group name
 		$name = array_shift($params);

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -1,7 +1,5 @@
 <?php namespace Myth\Auth\Config;
 
-use Config\Services;
-
 /**
  * Helper class that will register our bulk plugins
  * and filters with the View Parser class.
@@ -19,8 +17,8 @@ class Registrar
     {
         return [
             'plugins' => [
-                'logged_in' => [ function ($str, array $params = []) { return Services::authentication()->check() ? $str : ''; } ],
-                'logged_out' => [ function ($str, array $params = []) { return ! Services::authentication()->check() ? $str : ''; } ],
+                'logged_in' => [ function ($str, array $params = []) { return service('authentication')->check() ? $str : ''; } ],
+                'logged_out' => [ function ($str, array $params = []) { return ! service('authentication')->check() ? $str : ''; } ],
             ]
         ];
     }

--- a/src/Filters/LoginFilter.php
+++ b/src/Filters/LoginFilter.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Filters;
 
-use Config\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Filters\FilterInterface;
@@ -48,7 +47,7 @@ class LoginFilter implements FilterInterface
 		}
 
 		// if no user is logged in then send to the login form
-		$authenticate = Services::authentication();
+		$authenticate = service('authentication');
 		if (! $authenticate->check())
 		{
 			session()->set('redirect_url', current_url());

--- a/src/Filters/PermissionFilter.php
+++ b/src/Filters/PermissionFilter.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Filters;
 
-use Config\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Filters\FilterInterface;
@@ -35,7 +34,7 @@ class PermissionFilter implements FilterInterface
 			return;
 		}
 
-		$authenticate = Services::authentication();
+		$authenticate = service('authentication');
 
 		// if no user is logged in then send to the login form
 		if (! $authenticate->check())
@@ -44,7 +43,7 @@ class PermissionFilter implements FilterInterface
 			return redirect('login');
 		}
 
-		$authorize = Services::authorization();
+		$authorize = service('authorization');
 		$result = true;
 
 		// Check each requested permission

--- a/src/Filters/RoleFilter.php
+++ b/src/Filters/RoleFilter.php
@@ -1,6 +1,5 @@
 <?php namespace Myth\Auth\Filters;
 
-use Config\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Filters\FilterInterface;
@@ -35,7 +34,7 @@ class RoleFilter implements FilterInterface
 			return;
 		}
 
-		$authenticate = Services::authentication();
+		$authenticate = service('authentication');
 
 		// if no user is logged in then send to the login form
 		if (! $authenticate->check())
@@ -44,7 +43,7 @@ class RoleFilter implements FilterInterface
 			return redirect('login');
 		}
 
-		$authorize = Services::authorization();
+		$authorize = service('authorization');
 
 		// Check each requested permission
 		foreach ($params as $group)

--- a/src/Helpers/auth_helper.php
+++ b/src/Helpers/auth_helper.php
@@ -1,6 +1,5 @@
 <?php
 
-use Config\Services;
 
 if (! function_exists('logged_in'))
 {
@@ -11,7 +10,7 @@ if (! function_exists('logged_in'))
 	 */
 	function logged_in()
 	{
-		return Services::authentication()->check();
+		return service('authentication')->check();
 	}
 }
 
@@ -24,7 +23,7 @@ if (! function_exists('user'))
 	 */
 	function user()
 	{
-		$authenticate = Services::authentication();
+		$authenticate = service('authentication');
 		$authenticate->check();
 		return $authenticate->user();
 	}
@@ -39,7 +38,7 @@ if (! function_exists('user_id'))
 	 */
 	function user_id()
 	{
-		$authenticate = Services::authentication();
+		$authenticate = service('authentication');
 		$authenticate->check();
 		return $authenticate->id();
 	}
@@ -64,8 +63,8 @@ if (! function_exists('in_groups'))
 	 */
 	function in_groups($groups): bool
 	{
-		$authenticate = Services::authentication();
-        $authorize    = Services::authorization();
+		$authenticate = service('authentication');
+        $authorize    = service('authorization');
 
         if ($authenticate->check())
         {
@@ -88,8 +87,8 @@ if (! function_exists('has_permission'))
 	 */
 	function has_permission($permission): bool
 	{
-		$authenticate = Services::authentication();
-        $authorize    = Services::authorization();
+		$authenticate = service('authentication');
+        $authorize    = service('authorization');
 
         if ($authenticate->check())
         {


### PR DESCRIPTION
I've replaced all occurrences of `Config\Service` with the `service()` helper [as mentioned by @MGatner](https://github.com/lonnieezell/myth-auth/pull/355#pullrequestreview-659770515).

Moreover, with both my previous PRs (https://github.com/lonnieezell/myth-auth/pull/355 and https://github.com/lonnieezell/myth-auth/pull/347), I found a few bugs refactoring. I think that this project would benefit greatly by activating phpstan and using rector. 

Anyways, thanks for your work, hope this helps!