### PR TITLE
Username Constraints

### DIFF
--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -69,7 +69,7 @@ class ValidationRules
     {
         $fields = $this->prepareValidFields();
 
-        $data = service('request')->getPost($fields);
+        $data = array_filter(service('request')->getPost($fields));
 
         return new User($data);
     }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -153,7 +153,7 @@ class AuthController extends Controller
 		// Validate here first, since some things,
 		// like the password, can only be validated properly here.
 		$rules = [
-			'username'  	=> 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
+			'username'  	=> 'required|alpha_numeric_space|min_length[3]|max_length[30]|is_unique[users.username]',
 			'email'			=> 'required|valid_email|is_unique[users.email]',
 			'password'	 	=> 'required|strong_password',
 			'pass_confirm' 	=> 'required|matches[password]',

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -21,7 +21,7 @@ class UserModel extends Model
 
     protected $validationRules = [
         'email'         => 'required|valid_email|is_unique[users.email,id,{id}]',
-        'username'      => 'required|alpha_numeric_punct|min_length[3]|is_unique[users.username,id,{id}]',
+        'username'      => 'required|alpha_numeric_punct|min_length[3]|max_length[30]|is_unique[users.username,id,{id}]',
         'password_hash' => 'required',
     ];
     protected $validationMessages = [];

--- a/src/Test/Fakers/UserFaker.php
+++ b/src/Test/Fakers/UserFaker.php
@@ -17,7 +17,7 @@ class UserFaker extends UserModel
 	{
 		return new User([
 			'email'    => $faker->email,
-			'username' => implode('_', $faker->words),
+			'username' => $faker->userName,
 			'password' => bin2hex(random_bytes(16)),
 		]);
 	}


### PR DESCRIPTION
The `users` table has a constraint of 30 characters on `username`: https://github.com/lonnieezell/myth-auth/blob/fb0c8b8cae5b796d4f6d89e74ce6cab07966cdc1/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php#L15

This is not enforced by our Model and occasionally violated by `UserFaker`. Normally this just truncates the input, but with `strictOn` it causes a database error.

This PR adds the constraint to the User model and adjusts the faker to use `userName` (now that punctuation is allowed).