### PR TITLE
Prevalidate user fields

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -152,13 +152,21 @@ class AuthController extends Controller
 
 		$users = model(UserModel::class);
 
-		// Validate here first, since some things,
-		// like the password, can only be validated properly here.
+		// Validate basics first since some password rules rely on these fields
 		$rules = [
-			'username'  	=> 'required|alpha_numeric_space|min_length[3]|max_length[30]|is_unique[users.username]',
-			'email'			=> 'required|valid_email|is_unique[users.email]',
-			'password'	 	=> 'required|strong_password',
-			'pass_confirm' 	=> 'required|matches[password]',
+			'username' => 'required|alpha_numeric_space|min_length[3]|max_length[30]|is_unique[users.username]',
+			'email'    => 'required|valid_email|is_unique[users.email]',
+		];
+
+		if (! $this->validate($rules))
+		{
+			return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
+		}
+
+		// Validate passwords since they can only be validated properly here
+		$rules = [
+			'password'     => 'required|strong_password',
+			'pass_confirm' => 'required|matches[password]',
 		];
 
 		if (! $this->validate($rules))


### PR DESCRIPTION
Validation will run `strong_password` despite not having `valid_email` causing some of the password validation rules to fail. Probably the rules should be updated to account for this as well, but this quick fix splits out validation, which should fix the tests.