### PR TITLE
Fix cache() return value checks.

### DIFF
--- a/src/Authorization/GroupModel.php
+++ b/src/Authorization/GroupModel.php
@@ -92,7 +92,7 @@ class GroupModel extends Model
      */
     public function getGroupsForUser(int $userId)
     {
-        if (! $found = cache("{$userId}_groups"))
+        if (null === $found = cache("{$userId}_groups"))
         {
             $found = $this->builder()
                 ->select('auth_groups_users.*, auth_groups.name, auth_groups.description')
@@ -115,7 +115,7 @@ class GroupModel extends Model
      */
     public function getUsersForGroup(int $groupId)
     {
-        if (! $found = cache("{$groupId}_users"))
+        if (null === $found = cache("{$groupId}_users"))
         {
             $found = $this->builder()
                 ->select('auth_groups_users.*, users.*')

--- a/src/Authorization/PermissionModel.php
+++ b/src/Authorization/PermissionModel.php
@@ -99,7 +99,7 @@ class PermissionModel extends Model
      */
     public function getPermissionsForUser(int $userId): array
     {
-        if (! $found = cache("{$userId}_permissions"))
+        if (null === $found = cache("{$userId}_permissions"))
         {
             $fromUser = $this->db->table('auth_users_permissions')
                 ->select('id, auth_permissions.name')

--- a/tests/authorization/GroupModelTest.php
+++ b/tests/authorization/GroupModelTest.php
@@ -115,10 +115,54 @@ class GroupModelTest extends AuthTestCase
         ]);
         $this->assertEquals($result[1], [
             'group_id' => $group2->id,
-            'user_id' => $user->id,
+            'user_id'  => $user->id,
             'name' => $group2->name,
             'description' => $group2->description
         ]);
+    }
+
+    public function testGetGroupsForUserFromCache()
+    {
+        $user   = $this->createUser();
+        $group1 = $this->createGroup();
+        $group2 = $this->createGroup();
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user->id,
+            'group_id' => $group1->id
+        ]);
+
+        $cacheGroups = [
+            [
+                'group_id' => $group2->id,
+                'user_id' => $user->id,
+                'name' => 'notemptygroup',
+                'description' => 'This group can only be loaded from cache.'
+            ]
+        ];
+        cache()->save("{$user->id}_groups", $cacheGroups, 300);
+
+        $result = $this->model->getGroupsForUser($user->id);
+
+        $this->assertSame($result, $cacheGroups);
+    }
+
+    public function testGetEmptyGroupsForUserFromCache()
+    {
+        $user   = $this->createUser();
+        $group1 = $this->createGroup();
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user->id,
+            'group_id' => $group1->id
+        ]);
+
+        $cacheGroups = [];
+        cache()->save("{$user->id}_groups", $cacheGroups, 300);
+
+        $result = $this->model->getGroupsForUser($user->id);
+
+        $this->assertSame($result, $cacheGroups);
     }
 
     public function testGetUsersForGroup()
@@ -140,6 +184,47 @@ class GroupModelTest extends AuthTestCase
 
         $this->assertEquals($user1->id, $result[0]['id']);
         $this->assertEquals($user2->id, $result[1]['id']);
+    }
+
+    public function testGetUsersForGroupFromCache()
+    {
+        $group = $this->createGroup();
+        $user1 = fake(UserFaker::class);
+        $user2 = fake(UserFaker::class);
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user1->id,
+            'group_id' => $group->id
+        ]);
+
+        $cacheUsers = [
+            'group_id' => $group->id,
+            'user_id'  => $user2->id,
+            'email'    => 'gonnaSkip@theOtherProperties.lazy'
+        ];
+        cache()->save("{$group->id}_users", $cacheUsers, 300);
+
+        $result = $this->model->getUsersForGroup($group->id);
+
+        $this->assertSame($result, $cacheUsers);
+    }
+
+    public function testGetEmptyUsersForGroupFromCache()
+    {
+        $group = $this->createGroup();
+        $user = fake(UserFaker::class);
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'  => $user->id,
+            'group_id' => $group->id
+        ]);
+
+        $cacheUsers = [];
+        cache()->save("{$group->id}_users", $cacheUsers, 300);
+
+        $result = $this->model->getUsersForGroup($group->id);
+
+        $this->assertSame($result, $cacheUsers);
     }
 
     public function testAddPermissionToGroup()

--- a/tests/authorization/PermissionModelTest.php
+++ b/tests/authorization/PermissionModelTest.php
@@ -81,6 +81,41 @@ class PermissionModelTest extends AuthTestCase
         $this->assertEquals($expected, $this->model->getPermissionsForUser($user->id));
     }
 
+    public function testGetPermissionsForUserFromCache()
+    {
+        $user = $this->createUser();
+        $permission1 = $this->createPermission(['name' => 'first']);
+        $permission2 = $this->createPermission(['name' => 'second']);
+
+        $this->hasInDatabase('auth_users_permissions', [
+            'user_id' => $user->id,
+            'permission_id' => $permission1->id
+        ]);
+
+        $cachePermissions = [
+            $permission2->id => $permission2->name
+        ];
+        cache()->save("{$user->id}_permissions", $cachePermissions, 300);
+
+        $this->assertEquals($cachePermissions, $this->model->getPermissionsForUser($user->id));
+    }
+
+    public function testGetEmptyPermissionsForUserFromCache()
+    {
+        $user = $this->createUser();
+        $permission1 = $this->createPermission(['name' => 'first']);
+
+        $this->hasInDatabase('auth_users_permissions', [
+            'user_id' => $user->id,
+            'permission_id' => $permission1->id
+        ]);
+
+        $cachePermissions = [];
+        cache()->save("{$user->id}_permissions", $cachePermissions, 300);
+
+        $this->assertEquals($cachePermissions, $this->model->getPermissionsForUser($user->id));
+    }
+
     public function testDoesUserHavePermissionByGroupAssign()
     {
         $user = $this->createUser();


### PR DESCRIPTION
Closes #334.

`cache($key)` always returns the value read from cache or `null`.
The old `!cache()`-check will evaluate `true` for valid but empty cached values, e.g., `[]`, causing unnecessary database calls.