### PR TITLE
Remove cache of group after delete/add user to group

### DIFF
--- a/src/Authorization/GroupModel.php
+++ b/src/Authorization/GroupModel.php
@@ -34,7 +34,8 @@ class GroupModel extends Model
      * @return bool
      */
     public function addUserToGroup(int $userId, int $groupId)
-    {
+    {    
+        cache()->delete("{$groupId}_users");
         cache()->delete("{$userId}_groups");
         cache()->delete("{$userId}_permissions");
 
@@ -56,6 +57,7 @@ class GroupModel extends Model
      */
     public function removeUserFromGroup(int $userId, $groupId)
     {
+        cache()->delete("{$groupId}_users");
         cache()->delete("{$userId}_groups");
         cache()->delete("{$userId}_permissions");
 


### PR DESCRIPTION
Cache was not updating correctly, delete the group cache when user is added/removed from group.