### PR TITLE
Use "env" key instead of additional workflow step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,13 +55,11 @@ jobs:
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
-      - name: Enable Tachycardia
-        run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV
-
       - name: Test with PHPUnit
         run: vendor/bin/phpunit --verbose --coverage-text
         env:
           TERM: xterm-256color
+          TACHYCARDIA_MONITOR_GA: enabled
 
       - if: matrix.php-versions == '8.0'
         name: Mutate with Infection


### PR DESCRIPTION
Since Tachycardia is not conditionally enabled, we can just set the environment variable in the test run directly instead of creating an additional workflow step.