### PR TITLE
Update ValidationRules.php

### DIFF
--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -69,7 +69,14 @@ class ValidationRules
         $fields = $this->prepareValidFields();
 
         $data = array_filter(service('request')->getPost($fields));
-
+        
+        if (empty($data)) {
+            $data = array_intersect_key(
+                json_decode(service('request')->getBody(), true), 
+                array_fill_keys($fields, null)
+            );
+        }
+        
         return new User($data);
     }
 


### PR DESCRIPTION
When a request of type "application/json" was received, it caused an Exception of type ErrorException with the message "Undefined offset: 1".
This was because the buildUserFromRequest method in the myth-auth/src/Authentication/Passwords/ValidationRules.php file was not prepared for this request.
This patch fixes this issue.