### PR TITLE
fix(migrations): set keys as primary for associative tables

### DIFF
--- a/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
@@ -128,7 +128,7 @@ class CreateAuthTables extends Migration
         ];
 
         $this->forge->addField($fields);
-        $this->forge->addKey(['group_id', 'permission_id']);
+        $this->forge->addKey(['group_id', 'permission_id'], true);
         $this->forge->addForeignKey('group_id', 'auth_groups', 'id', '', 'CASCADE');
         $this->forge->addForeignKey('permission_id', 'auth_permissions', 'id', '', 'CASCADE');
         $this->forge->createTable('auth_groups_permissions', true);
@@ -142,7 +142,7 @@ class CreateAuthTables extends Migration
         ];
 
         $this->forge->addField($fields);
-        $this->forge->addKey(['group_id', 'user_id']);
+        $this->forge->addKey(['group_id', 'user_id'], true);
         $this->forge->addForeignKey('group_id', 'auth_groups', 'id', '', 'CASCADE');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
         $this->forge->createTable('auth_groups_users', true);
@@ -156,7 +156,7 @@ class CreateAuthTables extends Migration
         ];
 
         $this->forge->addField($fields);
-        $this->forge->addKey(['user_id', 'permission_id']);
+        $this->forge->addKey(['user_id', 'permission_id'], true);
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
         $this->forge->addForeignKey('permission_id', 'auth_permissions', 'id', '', 'CASCADE');
         $this->forge->createTable('auth_users_permissions', true);


### PR DESCRIPTION
Hello! I stumbled onto this as I was trying to seed MythAuth's associative tables, and having a lot of duplicates 😅

The keys for the `auth_groups_permissions`, `auth_groups_users` and `auth_users_permissions` should be both foreign **and primary** as they should be unique and they identify a given row.

--> It doesn't make sense to have a group given the same permission twice or more, nor to have a user in the same group multiple times, and so on…

That being said, I've set them as primary in the migration file. Hope it helps!