### PR TITLE
PostgreSQL support - proposal n.2: change tinyint to bools in database schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0']
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,36 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+          MYSQL_ROOT_PASSWORD: mythauth
+          MYSQL_DATABASE: mythauth
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
@@ -29,7 +59,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, pgsql, xdebug, xml, sqlite3
           coverage: xdebug
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,11 +85,37 @@ jobs:
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
-      - name: Test with PHPUnit
+      - name: Test with PHPUnit (SQLite)
         run: vendor/bin/phpunit --verbose --coverage-text
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled
+
+      - name: Test with PHPUnit (MySQL/MariaDB)
+        run: vendor/bin/phpunit --verbose --coverage-text
+        env:
+          TERM: xterm-256color
+          TACHYCARDIA_MONITOR_GA: enabled
+          database_tests_DBDriver: MySQLi
+          database.tests.hostname: 127.0.0.1
+          database_tests_port: 3306
+          database_tests_database: mythauth
+          database_tests_username: root
+          database_tests_password: mythauth
+          database.tests.DBPrefix: tests_
+
+      - name: Test with PHPUnit (PostgreSQL)
+        run: vendor/bin/phpunit --verbose --coverage-text
+        env:
+          TERM: xterm-256color
+          TACHYCARDIA_MONITOR_GA: enabled
+          database_tests_DBDriver: Postgre
+          database.tests.hostname: localhost
+          database_tests_port: 5432
+          database_tests_database: postgres
+          database_tests_username: postgres
+          database_tests_password: postgres
+          database.tests.DBPrefix: tests_
 
       - if: matrix.php-versions == '8.0'
         name: Mutate with Infection

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Myth:Auth
 
 [![](https://github.com/lonnieezell/myth-auth/workflows/PHPUnit/badge.svg)](https://github.com/lonnieezell/myth-auth/actions?query=workflow%3A%22PHPUnit%22)
-[![](https://github.com/lonnieezell/myth-auth/workflows/PHPStan/badge.svg)](https://github.com/lonnieezell/myth-auth/actions?query=workflow%3A%22PHPStan)
+[![](https://github.com/lonnieezell/myth-auth/workflows/PHPStan/badge.svg)](https://github.com/lonnieezell/myth-auth/actions?query=workflow%3A%22PHPStan%22)
 [![Coverage Status](https://coveralls.io/repos/github/lonnieezell/myth-auth/badge.svg?branch=develop)](https://coveralls.io/github/lonnieezell/myth-auth?branch=develop)
 
 Flexible, Powerful, Secure auth package for CodeIgniter 4.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -2,7 +2,7 @@
 
 ## Core classes
 
-`Authenticaion` and `Authorization` have their own interfaces and configurations. See the
+`Authentication` and `Authorization` have their own interfaces and configurations. See the
 appropriate docs for each component:
 * [Authentication](/docs/authentication.md)
 * [Authorization](/docs/authorization.md)
@@ -11,7 +11,7 @@ appropriate docs for each component:
 
 This library is intentionally slim on user identifying information, having only the fields necessary for
 authentication and authorization. You will likely want to add fields like a user's name or phone number,
-which you can do by can creating your own migration with these fields.
+which you can do by creating your own migration with these fields.
 
 ## Models
 

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -216,7 +216,7 @@ class AuthenticationBase
             'email' => $email,
             'user_id' => $userID,
             'date' => date('Y-m-d H:i:s'),
-            'success' => (int)$success
+            'success' => (bool)$success
         ]);
     }
 

--- a/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2017-11-20-223112_create_auth_tables.php
@@ -20,8 +20,8 @@ class CreateAuthTables extends Migration
             'activate_hash'    => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
             'status'           => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
             'status_message'   => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
-            'active'           => ['type' => 'tinyint', 'constraint' => 1, 'null' => 0, 'default' => 0],
-            'force_pass_reset' => ['type' => 'tinyint', 'constraint' => 1, 'null' => 0, 'default' => 0],
+            'active'           => ['type' => 'boolean',  'null' => false, 'default' => false],
+            'force_pass_reset' => ['type' => 'boolean',  'null' => false, 'default' => false],
             'created_at'       => ['type' => 'datetime', 'null' => true],
             'updated_at'       => ['type' => 'datetime', 'null' => true],
             'deleted_at'       => ['type' => 'datetime', 'null' => true],
@@ -42,7 +42,7 @@ class CreateAuthTables extends Migration
             'email'      => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
             'user_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true], // Only for successful logins
             'date'       => ['type' => 'datetime'],
-            'success'    => ['type' => 'tinyint', 'constraint' => 1],
+            'success'    => ['type' => 'boolean'],
         ]);
         $this->forge->addKey('id', true);
         $this->forge->addKey('email');

--- a/src/Entities/Cast/BooleanCast.php
+++ b/src/Entities/Cast/BooleanCast.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Myth\Auth\Entities\Cast;
+
+use CodeIgniter\Entity\Cast\BaseCast;
+
+/**
+ * Class BooleanCast
+ */
+class BooleanCast extends BaseCast
+{
+    /**
+     * {@inheritDoc}
+     */
+    public static function get($value, array $params = []): bool
+    {
+        // PostgreSQL (via PDO, etc.) returns (string)'f' or 't' for boolean
+        // fields
+        return (bool) $value && $value !== 'f';
+    }
+}

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -3,6 +3,7 @@
 use CodeIgniter\Entity;
 use Myth\Auth\Authorization\GroupModel;
 use Myth\Auth\Authorization\PermissionModel;
+use Myth\Auth\Entities\Cast\BooleanCast;
 use Myth\Auth\Password;
 
 class User extends Entity
@@ -29,8 +30,15 @@ class User extends Entity
      * when they are accessed.
      */
     protected $casts = [
-        'active'           => 'boolean',
-        'force_pass_reset' => 'boolean',
+        'active'           => 'booleanAuthMyth',
+        'force_pass_reset' => 'booleanAuthMyth',
+    ];
+
+    /**
+     * Registering our custom casting handler
+     */
+    protected $castHandlers = [
+        'booleanAuthMyth' => BooleanCast::class,
     ];
 
     /**
@@ -81,7 +89,7 @@ class User extends Entity
     public function forcePasswordReset()
     {
         $this->generateResetHash();
-        $this->attributes['force_pass_reset'] = 1;
+        $this->attributes['force_pass_reset'] = true;
 
         return $this;
     }
@@ -121,7 +129,7 @@ class User extends Entity
      */
     public function activate()
     {
-        $this->attributes['active'] = 1;
+        $this->attributes['active'] = true;
         $this->attributes['activate_hash'] = null;
 
         return $this;
@@ -134,7 +142,7 @@ class User extends Entity
      */
     public function deactivate()
     {
-        $this->attributes['active'] = 0;
+        $this->attributes['active'] = false;
 
         return $this;
     }

--- a/tests/authentication/AuthenticationBaseTest.php
+++ b/tests/authentication/AuthenticationBaseTest.php
@@ -56,7 +56,7 @@ class AuthenticationBaseTest extends AuthTestCase
         $this->seeInDatabase('auth_logins', [
             'email' => $user->email,
             'user_id' => $user->id,
-            'success' => 1
+            'success' => true,
         ]);
     }
 
@@ -70,7 +70,7 @@ class AuthenticationBaseTest extends AuthTestCase
         $this->seeInDatabase('auth_logins', [
             'email' => $user->email,
             'user_id' => $user->id,
-            'success' => 1
+            'success' => true,
         ]);
 
         $this->assertEquals(4, $_SESSION['logged_in']);
@@ -99,7 +99,7 @@ class AuthenticationBaseTest extends AuthTestCase
         $this->seeInDatabase('auth_logins', [
             'email' => $user->email,
             'user_id' => $user->id,
-            'success' => 1
+            'success' => true,
         ]);
 
         $this->assertEquals($user->id, $_SESSION['logged_in']);

--- a/tests/controllers/LoginTest.php
+++ b/tests/controllers/LoginTest.php
@@ -58,7 +58,7 @@ class LoginTest extends AuthTestCase
             'username' => 'Joe Cool',
             'email' => 'jc@example.com',
             'password' => 'xaH96AhjglK',
-            'active' => 1,
+            'active' => true,
         ];
         $this->createUser($user);
 
@@ -98,7 +98,7 @@ class LoginTest extends AuthTestCase
             'username' => 'Joe Cool',
             'email' => 'jc@example.com',
             'password' => 'xaH96AhjglK',
-            'active' => 1,
+            'active' => true,
         ];
         $this->createUser($user);
 

--- a/tests/unit/AuthenticationBaseLoginTest.php
+++ b/tests/unit/AuthenticationBaseLoginTest.php
@@ -40,7 +40,7 @@ class AuthenticationBaseLoginTest extends CIUnitTestCase
             'email' => 'joe@example.com',
             'user_id' => 12,
             'date' => date('Y-m-d H:i:s'),
-            'success' => 0
+            'success' => false,
         ]))->andReturn(true);
 
         $this->assertTrue($this->auth->recordLoginAttempt($credentials['email'], '0.0.0.0', 12, false));


### PR DESCRIPTION
This pull-request is a little more ambitious than #494 as it changes the database schema. The code change is bigger and more likely to introduce breaking scenario, but since MySQL & MariaDB implictly convert booleans fields to tinyint and since SQLite isn't strongly typed, the impact on existing deployments may still be acceptable.

Those patch set up a new casting class, taking care of the strange behaviour of PDO/PostgreSQL fetching `TRUE`/`FALSE` values as `(string)'t'`/`(string)'f'` by default. For now, this patch is still a work in progress as I would prefer and still hope to use `PDO::PARAM_*`.

Like #494 :
* Tests added to run on MySQL and PostgreSQL (on top of already running on SQLite). Since it seems that CodeIgniter 4.1.x sadly doesn't support PHP 7.3 anymore, I removed it from the tests' matrix.
* Those patches also fix a couple of typos.