### PR TITLE
Removed site_url("/") as it is redundant code

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -53,7 +53,7 @@ class AuthController extends Controller
         }
 
         // Set a return URL if none is specified
-        $_SESSION['redirect_url'] = session('redirect_url') ?? previous_url() ?? site_url('/');
+        $_SESSION['redirect_url'] = session('redirect_url') ?? previous_url();
 
         return $this->_render($this->config->views['login'], ['config' => $this->config]);
     }


### PR DESCRIPTION
Removed site_url("/") as it is redundant code because the previous_url() will return the "/" if there will be no value.
You can verify it with my below-generated issue.
https://github.com/lonnieezell/myth-auth/issues/550