### PR TITLE
Force new created user to reset a password

### DIFF
--- a/src/Commands/CreateUser.php
+++ b/src/Commands/CreateUser.php
@@ -40,6 +40,7 @@ class CreateUser extends BaseCommand
 
         // Run the user through the entity and insert it
         $user = new User($row);
+        $user->forcePasswordReset();
 
         $users = model(UserModel::class);
         if ($userId = $users->insert($user)) {


### PR DESCRIPTION
Forces a new created user with **php spark auth:create_user** command to reset their password on next page refresh or login.

Fixes #556 