### PR TITLE
fix BaseFilter not found error after publishing filters from cli

### DIFF
--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -214,6 +214,7 @@ class Publish extends BaseCommand
 
             $content = file_get_contents($path);
             $content = $this->replaceNamespace($content, 'Myth\Auth\Filters', 'Filters');
+            $content = str_replace('use CodeIgniter\HTTP\ResponseInterface;', 'use CodeIgniter\HTTP\ResponseInterface;' . PHP_EOL . 'use Myth\Auth\Filters\BaseFilter;', $content);
 
             $this->writeFile("Filters/{$filter}.php", $content);
         }


### PR DESCRIPTION
This will add 'use Myth\Auth\Filters\BaseFilter;' import to the all three filter files after publishing them by auth:publish command.
Fixes #568
Closes #569
Replaces #571