### PR TITLE
fix pipeline issues - rector error

### DIFF
--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -49,7 +49,7 @@ class GroupModel extends Model
             'group_id' => $groupId,
         ];
 
-        return (bool) $this->db->table('auth_groups_users')->insert($data);
+        return $this->db->table('auth_groups_users')->insert($data);
     }
 
     /**


### PR DESCRIPTION
addUserToGroup() method of **GroupModel** have a string
`return (bool) $this->db->table('auth_groups_users')->insert($data);`
which is not needed, because queryBuilder's insert method already returns boolean. So as Rector mentioned there is we have recasting issue.
