### PR TITLE
Fixes issue with compatibility to work with CodeIgniter 4.4+

### DIFF
--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -225,12 +225,12 @@ class AuthenticationBase
 
         // Replace cookie config values from cookie.php file on new versions of CI (v4.4.0 and above) for BC.
         if (version_compare(CodeIgniter::CI_VERSION, '4.3.8', '>')) {
-            $cookieConfig = config('Cookie');
-            $appConfig->cookieDomain    = $cookieConfig->domain;
-            $appConfig->cookiePath      = $cookieConfig->path;
-            $appConfig->cookiePrefix    = $cookieConfig->prefix;
-            $appConfig->cookieSecure    = $cookieConfig->secure;
-            $appConfig->cookieHTTPOnly  = $cookieConfig->httponly;
+            $cookieConfig              = config('Cookie');
+            $appConfig->cookieDomain   = $cookieConfig->domain;
+            $appConfig->cookiePath     = $cookieConfig->path;
+            $appConfig->cookiePrefix   = $cookieConfig->prefix;
+            $appConfig->cookieSecure   = $cookieConfig->secure;
+            $appConfig->cookieHTTPOnly = $cookieConfig->httponly;
         }
 
         // Create the cookie
@@ -272,12 +272,12 @@ class AuthenticationBase
 
         // Replace cookie config values from cookie.php file on new versions of CI (v4.4.0 and above) for BC.
         if (version_compare(CodeIgniter::CI_VERSION, '4.3.8', '>')) {
-            $cookieConfig = config('Cookie');
-            $appConfig->cookieDomain    = $cookieConfig->domain;
-            $appConfig->cookiePath      = $cookieConfig->path;
-            $appConfig->cookiePrefix    = $cookieConfig->prefix;
-            $appConfig->cookieSecure    = $cookieConfig->secure;
-            $appConfig->cookieHTTPOnly  = $cookieConfig->httponly;
+            $cookieConfig              = config('Cookie');
+            $appConfig->cookieDomain   = $cookieConfig->domain;
+            $appConfig->cookiePath     = $cookieConfig->path;
+            $appConfig->cookiePrefix   = $cookieConfig->prefix;
+            $appConfig->cookieSecure   = $cookieConfig->secure;
+            $appConfig->cookieHTTPOnly = $cookieConfig->httponly;
         }
 
         // Create the cookie

--- a/src/Authentication/AuthenticationBase.php
+++ b/src/Authentication/AuthenticationBase.php
@@ -2,6 +2,7 @@
 
 namespace Myth\Auth\Authentication;
 
+use CodeIgniter\CodeIgniter;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Model;
 use Exception;
@@ -222,6 +223,16 @@ class AuthenticationBase
         $appConfig = config('App');
         $response  = service('response');
 
+        // Replace cookie config values from cookie.php file on new versions of CI (v4.4.0 and above) for BC.
+        if (version_compare(CodeIgniter::CI_VERSION, '4.3.8', '>')) {
+            $cookieConfig = config('Cookie');
+            $appConfig->cookieDomain    = $cookieConfig->domain;
+            $appConfig->cookiePath      = $cookieConfig->path;
+            $appConfig->cookiePrefix    = $cookieConfig->prefix;
+            $appConfig->cookieSecure    = $cookieConfig->secure;
+            $appConfig->cookieHTTPOnly  = $cookieConfig->httponly;
+        }
+
         // Create the cookie
         $response->setCookie(
             'remember',      							// Cookie Name
@@ -258,6 +269,16 @@ class AuthenticationBase
         helper('cookie');
 
         $appConfig = config('App');
+
+        // Replace cookie config values from cookie.php file on new versions of CI (v4.4.0 and above) for BC.
+        if (version_compare(CodeIgniter::CI_VERSION, '4.3.8', '>')) {
+            $cookieConfig = config('Cookie');
+            $appConfig->cookieDomain    = $cookieConfig->domain;
+            $appConfig->cookiePath      = $cookieConfig->path;
+            $appConfig->cookiePrefix    = $cookieConfig->prefix;
+            $appConfig->cookieSecure    = $cookieConfig->secure;
+            $appConfig->cookieHTTPOnly  = $cookieConfig->httponly;
+        }
 
         // Create the cookie
         set_cookie(


### PR DESCRIPTION
In version CodeIgniter 4.4.0 cookie settings have moved to dedicated file and the parameter names have changed. 
Closes #606 
Closes #602 
Supersedes #607 