### PR TITLE
Fix Faker's depricated email and userName properties

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -116,8 +116,8 @@ class UserModel extends Model
     public function fake(Generator &$faker): User
     {
         return new User([
-            'email'    => $faker->email,
-            'username' => $faker->userName,
+            'email'    => $faker->email(),
+            'username' => $faker->userName(),
             'password' => bin2hex(random_bytes(16)),
         ]);
     }


### PR DESCRIPTION
Since fakerphp/faker 1.14 accessing properties "userName" and "email" is deprecated.
Closes #599 