### PR TITLE
refactor: Replace deprecated Faker property access

### DIFF
--- a/src/Test/Fakers/GroupFaker.php
+++ b/src/Test/Fakers/GroupFaker.php
@@ -14,8 +14,8 @@ class GroupFaker extends GroupModel
     public function fake(Generator &$faker): stdClass
     {
         return (object) [
-            'name'        => $faker->word,
-            'description' => $faker->sentence,
+            'name'        => $faker->word(),
+            'description' => $faker->sentence(),
         ];
     }
 }

--- a/src/Test/Fakers/PermissionFaker.php
+++ b/src/Test/Fakers/PermissionFaker.php
@@ -13,8 +13,8 @@ class PermissionFaker extends PermissionModel
     public function fake(Generator &$faker): array
     {
         return [
-            'name'        => $faker->word,
-            'description' => $faker->sentence,
+            'name'        => $faker->word(),
+            'description' => $faker->sentence(),
         ];
     }
 }


### PR DESCRIPTION
Direct property access is deprecated since Faker v1.14.