### PR TITLE
Banned Reason Message On Login

### DIFF
--- a/src/Authentication/LocalAuthenticator.php
+++ b/src/Authentication/LocalAuthenticator.php
@@ -33,7 +33,7 @@ class LocalAuthenticator extends AuthenticationBase implements AuthenticatorInte
             $ipAddress = service('request')->getIPAddress();
             $this->recordLoginAttempt($credentials['email'] ?? $credentials['username'], $ipAddress, $this->user->id ?? null, false);
 
-            $this->error = lang('Auth.userIsBanned');
+            $this->error = $this->user->status_message && !empty($this->user->status_message) ? $this->user->status_message : lang('Auth.userIsBanned');
 
             $this->user = null;
 


### PR DESCRIPTION
I saw that in the user entity there is a function to ban the user `ban()` with the parameter for the reason for being banned, and after I checked in the database the parameter will be saved in the status_message column.

The strange thing for me is that users don't know why they were banned, but we have the data. I tried to update the code a little to be able to tell you the reason for being banned. 

The changes I made will check whether `status_message` is null and is an empty string, and if it meets the requirements, it will display a message according to what is stored in the database.