### PR TITLE
Fix ValidatorInterface error after upgrading to CodeIgniter 4.5

### DIFF
--- a/src/Authentication/Passwords/ValidatorInterface.php
+++ b/src/Authentication/Passwords/ValidatorInterface.php
@@ -2,7 +2,7 @@
 
 namespace Myth\Auth\Authentication\Passwords;
 
-use CodeIgniter\Entity;
+use CodeIgniter\Entity\Entity;
 
 interface ValidatorInterface
 {


### PR DESCRIPTION
Fix ValidatorInterface error due to removed deprecated `CodeIgniter\Entity`